### PR TITLE
fix(backend): add CORS configuration for frontend communication

### DIFF
--- a/backend/src/main/java/com/example/gardenmonitor/config/CorsConfig.java
+++ b/backend/src/main/java/com/example/gardenmonitor/config/CorsConfig.java
@@ -1,0 +1,28 @@
+package com.example.gardenmonitor.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/api/**")
+                        .allowedOrigins(
+                            "http://localhost:5173",
+                            "https://vocational-training-final-project.vercel.app"
+                        )
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedHeaders("*")
+                        .allowCredentials(true)
+                        .maxAge(3600);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Resumen
- Añade configuración CORS para permitir peticiones desde el frontend
- Permite origen local (localhost:5173) y producción (vocational-training-final-project.vercel.app)
- Soporta todos los métodos HTTP necesarios (GET, POST, PUT, DELETE, OPTIONS)

## Cambios
- Creada clase `CorsConfig` en `backend/src/main/java/com/example/gardenmonitor/config/`

## Testing
Después de mergear y redesplegar en Render, el frontend debería poder comunicarse con el backend sin errores CORS.