### PR TITLE
fix(backend): use allowedOriginPatterns for CORS configuration

### DIFF
--- a/backend/src/main/java/com/example/gardenmonitor/config/CorsConfig.java
+++ b/backend/src/main/java/com/example/gardenmonitor/config/CorsConfig.java
@@ -14,7 +14,7 @@ public class CorsConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/api/**")
-                        .allowedOrigins(
+                        .allowedOriginPatterns(
                             "http://localhost:5173",
                             "https://vocational-training-final-project.vercel.app"
                         )


### PR DESCRIPTION
## Problema
El backend estaba lanzando este error:
```
When allowCredentials is true, allowedOrigins cannot contain the special value "*" since that cannot be set on the "Access-Control-Allow-Origin" response header.
```

## Solución
- Cambiar `.allowedOrigins()` por `.allowedOriginPatterns()`
- Esto resuelve el conflicto con `allowCredentials(true)`

## Testing
Después de mergear y redesplegar en Render, el frontend debería poder comunicarse con el backend sin errores CORS.