### PR TITLE
fix(backend): remove @CrossOrigin annotations from controllers

### DIFF
--- a/backend/src/main/java/com/example/gardenmonitor/controller/ArbolController.java
+++ b/backend/src/main/java/com/example/gardenmonitor/controller/ArbolController.java
@@ -12,7 +12,6 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
-@CrossOrigin(origins = "*")
 @RestController
 @RequestMapping("/api/arboles")
 public class ArbolController {

--- a/backend/src/main/java/com/example/gardenmonitor/controller/CentroEducativoController.java
+++ b/backend/src/main/java/com/example/gardenmonitor/controller/CentroEducativoController.java
@@ -21,7 +21,6 @@ import java.util.List;
  * @author Richard Ortiz y Enrique Pérez
  * @version 1.0
  */
-@CrossOrigin(origins = "*")
 @RestController
 @RequestMapping("/api/centros")
 public class CentroEducativoController {

--- a/backend/src/main/java/com/example/gardenmonitor/controller/UsuarioController.java
+++ b/backend/src/main/java/com/example/gardenmonitor/controller/UsuarioController.java
@@ -10,7 +10,6 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
-@CrossOrigin(origins = "*")
 @RestController
 @RequestMapping("/api/usuarios")
 public class UsuarioController {


### PR DESCRIPTION
## Problema
Los controladores tenían anotaciones `@CrossOrigin(origins = "*")` que entraban en conflicto con la configuración CORS global que usa `allowCredentials(true)`.

Esto causaba el error:
```
When allowCredentials is true, allowedOrigins cannot contain the special value "*"
```

## Solución
- Eliminar todas las anotaciones `@CrossOrigin` de los controladores
- La configuración CORS global en `CorsConfig` maneja todo correctamente

## Archivos modificados
- ArbolController.java
- CentroEducativoController.java
- UsuarioController.java