### PR TITLE
feat(android): add build variants for environment management

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -43,29 +43,35 @@ cd android
 - Seleccionar carpeta `android/`
 - Esperar a que Gradle sincronice las dependencias
 
-### 3. Configurar URL del Backend
+### 3. Seleccionar Build Variant
 
-La aplicación está configurada para conectarse al backend en producción:
+La aplicación usa **Build Variants** para gestionar la conexión a diferentes backends sin modificar código.
 
-**RetrofitClient.java:**
-```java
-private static final String BASE_URL = "https://proyecto-arboles-backend.onrender.com/";
-```
+**En Android Studio:**
+1. Ve a **View → Tool Windows → Build Variants**
+2. Selecciona el variant según tu entorno:
 
-Para desarrollo local, cambiar a:
-```java
-private static final String BASE_URL = "http://10.0.2.2:8080/"; // Emulador Android
-// o
-private static final String BASE_URL = "http://TU_IP_LOCAL:8080/"; // Dispositivo físico
-```
+| Build Variant | Backend | Uso |
+|---------------|---------|-----|
+| `localEmulatorDebug` | `http://10.0.2.2:8080/` | Desarrollo con emulador + backend local |
+| `localDeviceDebug` | `http://192.168.1.158:8080/` | Desarrollo con móvil físico + backend local |
+| `productionDebug` | `https://proyecto-arboles-backend.onrender.com/` | Pruebas contra producción |
+| `productionRelease` | `https://proyecto-arboles-backend.onrender.com/` | **APK final para distribución** |
+
+> **Nota**: Si usas `localDevice*`, verifica que la IP en `build.gradle.kts` coincida con la de tu ordenador.
 
 ### 4. Compilar y ejecutar
 
+**Desde terminal (variant por defecto):**
 ```bash
-./gradlew assembleDebug
+./gradlew assembleLocalEmulatorDebug   # Para emulador + backend local
+./gradlew assembleProductionDebug       # Para producción
+./gradlew assembleProductionRelease     # APK final
 ```
 
-O desde Android Studio: Run → Run 'app'
+**Desde Android Studio:**
+1. Selecciona el Build Variant deseado (paso 3)
+2. Run → Run 'app' (o Shift+F10)
 
 ## Estructura del Proyecto
 
@@ -78,18 +84,18 @@ android/
 │   │   │   │   └── com/example/proyectoarboles/
 │   │   │   │       ├── activities/    # Login, Registrer, ListarArboles, ArbolDetalles
 │   │   │   │       ├── adapter/       # ArbolAdapter, BigDecimalStringAdapter
-│   │   │   │       ├── api/           # ApiClient, ApiService, AuthInterceptor
+│   │   │   │       ├── api/           # RetrofitClient, ArbolApi
 │   │   │   │       └── model/         # Arbol, CentroEducativo
 │   │   │   ├── res/
 │   │   │   │   ├── layout/           # activity_*.xml, item_arbol.xml
 │   │   │   │   └── values/           # strings.xml, colors.xml, themes.xml
 │   │   │   └── AndroidManifest.xml
 │   │   └── test/
-│   ├── build.gradle
+│   ├── build.gradle.kts              # Configuración del módulo app (con Build Variants)
 │   └── proguard-rules.pro
 ├── gradle/
-├── build.gradle
-├── settings.gradle
+├── build.gradle.kts                  # Configuración raíz
+├── settings.gradle.kts
 ├── .gitignore
 └── README.md
 ```
@@ -191,7 +197,7 @@ La app Android está completamente funcional, conectada al backend desplegado en
 
 **Repositorio**: [github.com/riordi80/vocational-training-final-project](https://github.com/riordi80/vocational-training-final-project)
 
-**Última actualización**: 2025-12-08
+**Última actualización**: 2026-01-21
 
 ### Colaboradores
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,6 +18,30 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    // Habilitar BuildConfig para acceder a las variables
+    buildFeatures {
+        buildConfig = true
+    }
+
+    // Dimensión para agrupar los flavors
+    flavorDimensions += "environment"
+
+    productFlavors {
+        create("localEmulator") {
+            dimension = "environment"
+            buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:8080/\"")
+        }
+        create("localDevice") {
+            dimension = "environment"
+            // Cambia esta IP si tu red local asigna otra a tu PC
+            buildConfigField("String", "BASE_URL", "\"http://192.168.1.158:8080/\"")
+        }
+        create("production") {
+            dimension = "environment"
+            buildConfigField("String", "BASE_URL", "\"https://proyecto-arboles-backend.onrender.com/\"")
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false

--- a/android/app/src/main/java/com/example/proyectoarboles/api/RetrofitClient.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/api/RetrofitClient.java
@@ -1,5 +1,6 @@
 package com.example.proyectoarboles.api;
 
+import com.example.proyectoarboles.BuildConfig;
 import com.example.proyectoarboles.adapter.BigDecimalStringAdapter;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -12,7 +13,8 @@ import retrofit2.converter.gson.GsonConverterFactory;
 
 public class RetrofitClient {
 
-    private static final String BASE_URL = "https://proyecto-arboles-backend.onrender.com/";
+    // URL configurada automáticamente según el Build Flavor seleccionado
+    private static final String BASE_URL = BuildConfig.BASE_URL;
 
     private static Retrofit retrofit = null;
     private static ArbolApi arbolApi = null;

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -4,14 +4,14 @@
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 
-    <!-- Primary colors (Green) - matching frontend -->
+    <!-- Primary colors (Green) -->
     <color name="green_primary">#16a34a</color>
     <color name="green_primary_dark">#15803d</color>
     <color name="green_primary_light">#22c55e</color>
     <color name="green_50">#f0fdf4</color>
     <color name="green_100">#dcfce7</color>
 
-    <!-- Secondary colors (Gray) - matching frontend -->
+    <!-- Secondary colors (Gray) -->
     <color name="gray_50">#f9fafb</color>
     <color name="gray_100">#f3f4f6</color>
     <color name="gray_200">#e5e7eb</color>
@@ -19,7 +19,7 @@
     <color name="gray_600">#4b5563</color>
     <color name="gray_800">#1f2937</color>
 
-    <!-- Danger colors (Red) - matching frontend -->
+    <!-- Danger colors (Red) -->
     <color name="red_primary">#dc2626</color>
     <color name="red_primary_dark">#b91c1c</color>
 

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Button Styles - matching frontend design -->
 
-    <!-- Primary Button (Green) -->
+    <!-- Botón Primario Button (Verde) -->
     <style name="ButtonPrimary" parent="Widget.Material3.Button">
         <item name="backgroundTint">@color/green_primary</item>
         <item name="android:textColor">@color/white</item>
@@ -15,7 +14,7 @@
         <item name="android:fontFamily">sans-serif-medium</item>
     </style>
 
-    <!-- Secondary Button (Gray) -->
+    <!-- Botón Secundario (Gris) -->
     <style name="ButtonSecondary" parent="Widget.Material3.Button">
         <item name="backgroundTint">@color/gray_200</item>
         <item name="android:textColor">@color/gray_800</item>
@@ -28,7 +27,7 @@
         <item name="android:fontFamily">sans-serif-medium</item>
     </style>
 
-    <!-- Danger Button (Red) -->
+    <!-- Boton Danger (Rojo) -->
     <style name="ButtonDanger" parent="Widget.Material3.Button">
         <item name="backgroundTint">@color/red_primary</item>
         <item name="android:textColor">@color/white</item>
@@ -41,7 +40,7 @@
         <item name="android:fontFamily">sans-serif-medium</item>
     </style>
 
-    <!-- Outline Button (Green border) -->
+    <!-- Boton con borde (Borde verde) -->
     <style name="ButtonOutline" parent="Widget.Material3.Button.OutlinedButton">
         <item name="strokeColor">@color/green_primary</item>
         <item name="android:textColor">@color/green_primary</item>
@@ -55,7 +54,7 @@
         <item name="android:fontFamily">sans-serif-medium</item>
     </style>
 
-    <!-- Card Style -->
+    <!-- Card -->
     <style name="CardStyle" parent="Widget.Material3.CardView.Elevated">
         <item name="cardBackgroundColor">@color/background_card</item>
         <item name="cardCornerRadius">12dp</item>
@@ -64,7 +63,7 @@
         <item name="android:layout_margin">8dp</item>
     </style>
 
-    <!-- Section Header Style -->
+    <!-- Header -->
     <style name="SectionHeader">
         <item name="android:textSize">18sp</item>
         <item name="android:textStyle">bold</item>
@@ -73,7 +72,7 @@
         <item name="android:paddingBottom">8dp</item>
     </style>
 
-    <!-- Field Label Style -->
+    <!-- Field Label -->
     <style name="FieldLabel">
         <item name="android:textSize">14sp</item>
         <item name="android:textStyle">bold</item>

--- a/docs/MANUAL_DE_INSTALACION_ANDROID.md
+++ b/docs/MANUAL_DE_INSTALACION_ANDROID.md
@@ -15,29 +15,17 @@
 
 ## Configuración del Backend
 
-La aplicación Android se conecta al backend desplegado en producción por defecto. Si deseas usar un backend local para desarrollo:
+La aplicación Android utiliza **Build Variants** para gestionar la conexión a diferentes backends sin modificar código. Esto permite cambiar fácilmente entre desarrollo local y producción.
 
-1. El backend debe estar corriendo en el puerto **8080**
-2. Anota la dirección IP de tu servidor backend
-3. Modifica la URL en `RetrofitClient.java` (ver sección siguiente)
+**Build Variants disponibles:**
 
-### Configuración de la URL del Backend
+| Entorno | Build Variant | URL |
+|---------|---------------|-----|
+| Emulador + backend local | `localEmulatorDebug` | `http://10.0.2.2:8080/` |
+| Móvil físico + backend local | `localDeviceDebug` | `http://192.168.1.158:8080/` |
+| Producción (Render) | `productionDebug` / `productionRelease` | `https://proyecto-arboles-backend.onrender.com/` |
 
-La aplicación está configurada para conectarse al backend en producción mediante la clase `RetrofitClient.java`:
-
-```java
-// En: app/src/main/java/com/example/proyectoarboles/api/RetrofitClient.java
-
-private static final String BASE_URL = "https://proyecto-arboles-backend.onrender.com/";
-```
-
-**Opciones de configuración según tu entorno:**
-
-- **Producción (por defecto)**: `https://proyecto-arboles-backend.onrender.com/`
-- **Emulador de Android (desarrollo local)**: `http://10.0.2.2:8080/`
-- **Dispositivo físico (desarrollo local)**: `http://TU_IP_LOCAL:8080/`
-  - Ejemplo: `http://192.168.1.100:8080/`
-  - Asegúrate de que el dispositivo y el ordenador estén en la misma red WiFi
+Para más detalles sobre cómo seleccionar un Build Variant, consulta la **Sección 8: Build Variants**.
 
 ## Instalación Paso a Paso
 
@@ -184,98 +172,102 @@ Si la app no puede conectarse, verifica que el `AndroidManifest.xml` incluya:
 
 ## Compilar APK para Distribución
 
-Para generar un APK instalable:
+Para generar un APK instalable para producción:
 
-1. Ve a **Build > Build Bundle(s) / APK(s) > Build APK(s)**
-2. Espera a que se complete la compilación
-3. Haz clic en **locate** para encontrar el APK generado
-4. El APK estará en: `app/build/outputs/apk/debug/app-debug.apk`
+1. Selecciona el Build Variant **`productionRelease`** (View > Tool Windows > Build Variants)
+2. Ve a **Build > Build Bundle(s) / APK(s) > Build APK(s)**
+3. Espera a que se complete la compilación
+4. Haz clic en **locate** para encontrar el APK generado
+5. El APK estará en: `app/build/outputs/apk/production/release/app-production-release.apk`
+
+**Nota**: Para desarrollo/pruebas, el APK debug estará en `app/build/outputs/apk/[variant]/debug/`
 
 ## Notas Adicionales
 
-- La aplicación **se conecta por defecto al backend en producción** (Render)
+- La aplicación usa **Build Variants** para seleccionar el entorno (local/producción)
+- Para producción, usa el variant `productionDebug` o `productionRelease`
 - Incluye un sistema de **fallback** con datos XML en caso de que la API no esté disponible
 - Los datos de sensores se generan aleatoriamente para demostración
 - El modo de edición permite modificar todos los campos del árbol
 - Las validaciones básicas están implementadas en el login y registro
 - **Timeout configurado**: 60 segundos (adecuado para el free tier de Render)
 
-## 8. Configuración: Desarrollo Local vs Producción
+## 8. Build Variants: Seleccionar Entorno de Desarrollo
 
-### Configuración de la URL del Backend
+### ¿Qué son los Build Variants?
 
-La aplicación Android tiene la URL del backend hardcoded en el código fuente. Necesitarás cambiarla manualmente dependiendo de si estás trabajando en desarrollo local o producción.
+Los Build Variants permiten compilar diferentes versiones de la aplicación sin modificar el código fuente. Cada variant tiene su propia URL de backend configurada automáticamente.
 
-**Archivo**: `android/app/src/main/java/com/example/proyectoarboles/api/RetrofitClient.java`
+La aplicación tiene **6 Build Variants** disponibles:
 
-### Configuración para Producción (Actual)
+| Build Variant | URL del Backend | Uso |
+|---------------|-----------------|-----|
+| `localEmulatorDebug` | `http://10.0.2.2:8080/` | Desarrollo con emulador + backend local |
+| `localEmulatorRelease` | `http://10.0.2.2:8080/` | Probar release con emulador + backend local |
+| `localDeviceDebug` | `http://192.168.1.158:8080/` | Desarrollo con móvil físico + backend local |
+| `localDeviceRelease` | `http://192.168.1.158:8080/` | Probar release con móvil físico + backend local |
+| `productionDebug` | `https://proyecto-arboles-backend.onrender.com/` | Debugging contra servidor de producción |
+| `productionRelease` | `https://proyecto-arboles-backend.onrender.com/` | **APK final para distribución** |
 
-```java
-private static final String BASE_URL = "https://proyecto-arboles-backend.onrender.com/";
-```
+### Cómo Seleccionar un Build Variant
 
-Esta es la configuración actual que apunta al backend desplegado en Render.
+1. En Android Studio, ve a **View > Tool Windows > Build Variants** (o usa el panel lateral izquierdo)
+2. En el panel que aparece, haz clic en el dropdown de tu módulo `:app`
+3. Selecciona el variant adecuado según tu situación:
 
-### Configuración para Desarrollo Local
+#### Flujo de Trabajo Recomendado
 
-Si quieres trabajar con el backend en local, necesitas cambiar la URL según el tipo de dispositivo:
+| Situación | Build Variant a usar |
+|-----------|---------------------|
+| Desarrollo diario con emulador y backend local | `localEmulatorDebug` |
+| Desarrollo con móvil físico y backend local | `localDeviceDebug` |
+| Probar contra el servidor de producción (Render) | `productionDebug` |
+| Generar APK final para distribución | `productionRelease` |
 
-#### Para Emulador Android:
+### Configuración para Dispositivo Físico
 
-```java
-private static final String BASE_URL = "http://10.0.2.2:8080/";
-```
+Si usas `localDeviceDebug` o `localDeviceRelease`, necesitas verificar que la IP configurada sea correcta:
 
-**Explicación**: El emulador de Android usa `10.0.2.2` como alias para `localhost` de tu ordenador.
-
-#### Para Dispositivo Físico:
-
-```java
-private static final String BASE_URL = "http://192.168.1.X:8080/";
-```
-
-**Pasos**:
 1. Obtén tu IP local:
    - **Linux/Mac**: `ip addr` o `ifconfig`
    - **Windows**: `ipconfig`
-2. Reemplaza `192.168.1.X` con tu IP real (ej: `192.168.1.105`)
+
+2. Si tu IP es diferente a `192.168.1.158`, modifica el archivo `android/app/build.gradle.kts`:
+
+   ```kotlin
+   create("localDevice") {
+       dimension = "environment"
+       // Cambia esta IP por la de tu ordenador
+       buildConfigField("String", "BASE_URL", "\"http://TU_IP_LOCAL:8080/\"")
+   }
+   ```
+
 3. Asegúrate de que el ordenador y el dispositivo estén en la misma red WiFi
 
-### Flujo de Trabajo Recomendado
+### Diferencia entre Debug y Release
 
-#### Desarrollo Local:
+| Característica | Debug | Release |
+|----------------|-------|---------|
+| Debuggable | Sí (puedes usar breakpoints) | No |
+| Optimizado | No | Sí (si `isMinifyEnabled = true`) |
+| Velocidad de compilación | Rápida | Más lenta |
+| Firma | Automática (debug keystore) | Manual (requiere keystore de producción) |
 
-1. Asegúrate de que el backend esté corriendo localmente:
-   ```bash
-   cd backend
-   ./mvnw spring-boot:run
-   # Backend en http://localhost:8080
-   ```
+**Para desarrollo diario**, usa siempre variantes `Debug`.
+**Para distribución final**, usa `productionRelease`.
 
-2. Modifica `RetrofitClient.java`:
-   ```java
-   private static final String BASE_URL = "http://10.0.2.2:8080/";
-   ```
+### Ventajas de usar Build Variants
 
-3. Ejecuta la aplicación desde Android Studio
-
-4. **IMPORTANTE**: No hagas commit de este cambio. Antes de hacer commit, vuelve a poner la URL de producción.
-
-#### Producción:
-
-1. Asegúrate de que `RetrofitClient.java` apunte a Render:
-   ```java
-   private static final String BASE_URL = "https://proyecto-arboles-backend.onrender.com/";
-   ```
-
-2. Compila el APK para distribución
+- **Sin riesgo de errores**: No necesitas modificar código fuente para cambiar de entorno
+- **Sin commits accidentales**: La URL correcta está siempre en el código
+- **Cambio instantáneo**: Solo selecciona el variant y ejecuta
+- **Profesional**: Es la forma estándar en desarrollo Android
 
 ### Notas Importantes
 
-- A diferencia del Frontend y Backend, la aplicación Android **requiere cambio manual** del código fuente
-- Recuerda revertir los cambios de URL antes de hacer commit al repositorio
-- Si trabajas en equipo, coordina para no commitear la URL de desarrollo local
-- Considera usar BuildConfig o variables de entorno en versiones futuras para automatizar esto
+- El código accede a la URL mediante `BuildConfig.BASE_URL` (configurado en `RetrofitClient.java`)
+- Al cambiar de variant, Android Studio recompilará automáticamente
+- Los variants `localDevice*` requieren que configures tu IP local en `build.gradle.kts`
 
 ---
 
@@ -298,7 +290,7 @@ Para problemas adicionales:
 
 **Repositorio**: [github.com/riordi80/vocational-training-final-project](https://github.com/riordi80/vocational-training-final-project)
 
-**Última actualización**: 2025-12-08
+**Última actualización**: 2026-01-21
 
 ### Colaboradores
 


### PR DESCRIPTION
## Summary
- Add productFlavors (localEmulator, localDevice, production) for environment-specific builds
- Configure BuildConfig.BASE_URL for automatic URL switching
- Update RetrofitClient to use BuildConfig instead of hardcoded URL
- Update documentation with build variants usage guide

## Test plan
- [ ] Select `localEmulatorDebug` variant and verify connection to local backend on emulator
- [ ] Select `productionDebug` variant and verify connection to Render backend
- [ ] Verify documentation is clear and accurate