### PR TITLE
chore(android): update Android Gradle Plugin to 8.13.2

### DIFF
--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.1"
+agp = "8.13.2"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"


### PR DESCRIPTION
## Summary
- Update Android Gradle Plugin from 8.13.1 to 8.13.2
- Patch update with bug fixes and improvements

## Test plan
- [ ] Verify project builds successfully
- [ ] Verify app runs on emulator/device