### PR TITLE
feat(frontend): add permissions utilities and hook

### DIFF
--- a/frontend/src/hooks/usePermissions.js
+++ b/frontend/src/hooks/usePermissions.js
@@ -1,0 +1,15 @@
+import { useAuth } from '../context/AuthContext';
+import { isAdminUser, canCreateArbol, canEditArbol, canDeleteArbol, canManageCenter, canAssignUsersToCenter } from '../utils/permissions';
+
+export function usePermissions() {
+  const { user } = useAuth();
+
+  return {
+    isAdmin: () => isAdminUser(user),
+    canCreateArbol: (centroId) => canCreateArbol(user, centroId),
+    canEditArbol: (centroId) => canEditArbol(user, centroId),
+    canDeleteArbol: (centroId) => canDeleteArbol(user, centroId),
+    canManageCenter: (centroId) => canManageCenter(user, centroId),
+    canAssignUsersToCenter: (centroId) => canAssignUsersToCenter(user, centroId),
+  };
+}

--- a/frontend/src/utils/permissions.js
+++ b/frontend/src/utils/permissions.js
@@ -1,0 +1,36 @@
+import { ROLES, ROLES_CENTRO } from "../constants/roles";
+
+export function isAdminUser(user) {
+  return user.rol === ROLES.ADMIN;
+}
+
+export function hasRoleInCenter(user, centroId, roles) {
+  if (isAdminUser(user)) {
+    return true;
+  }
+  const asignacion = user.centros.find(c => c.centroId === centroId);
+  if (!asignacion) {
+    return false;
+  }
+  return roles.includes(asignacion.rolEnCentro);
+}
+
+export function canCreateArbol(user, centroId) {
+  return hasRoleInCenter(user, centroId, [ROLES_CENTRO.COORDINADOR, ROLES_CENTRO.PROFESOR]);
+}
+
+export function canEditArbol(user, centroId) {
+  return hasRoleInCenter(user, centroId, [ROLES_CENTRO.COORDINADOR, ROLES_CENTRO.PROFESOR]);
+}
+
+export function canDeleteArbol(user, centroId) {
+  return hasRoleInCenter(user, centroId, [ROLES_CENTRO.COORDINADOR]);
+}
+
+export function canManageCenter(user, centroId) {
+  return hasRoleInCenter(user, centroId, [ROLES_CENTRO.COORDINADOR]);
+}
+
+export function canAssignUsersToCenter(user, centroId){
+  return hasRoleInCenter(user, centroId, [ROLES_CENTRO.COORDINADOR]);
+}


### PR DESCRIPTION
## Summary
- Añade `src/utils/permissions.js` con funciones de verificación de permisos
- Añade `src/hooks/usePermissions.js` para usar en componentes React

## Funciones incluidas
- `isAdminUser(user)` - Verifica si es administrador
- `hasRoleInCenter(user, centroId, roles)` - Verifica rol en centro
- `canCreateArbol`, `canEditArbol`, `canDeleteArbol` - Permisos de árboles
- `canManageCenter`, `canAssignUsersToCenter` - Permisos de centro

## Test plan
- [ ] Verificar que las funciones se exportan correctamente
- [ ] Probar integración con AuthContext en Fase 2