### PR TITLE
feat(frontend): update AuthContext with mock users and roles

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -10,6 +10,67 @@ export const useAuth = () => {
     return context;
 };
 
+// EN DESARROLLO...
+const MOCK_USERS = {
+    'admin@test.com': {
+        id: 1,
+        nombre: 'Admin',
+        email: 'admin@test.com',
+        password: 'admin123',
+        rol: 'ADMIN',
+        centros: []
+    },
+    'coordinador@test.com': {
+        id: 2,
+        nombre: 'Coordinador',
+        email: 'coordinador@test.com',
+        password: 'coord123',
+        rol: 'USUARIO',
+        centros: [
+            { centroId: 1, rolEnCentro: 'COORDINADOR' }
+        ]
+    },
+    'profesor@test.com': {
+        id: 3,
+        nombre: 'Profesor',
+        email: 'profesor@test.com',
+        password: 'prof123',
+        rol: 'USUARIO',
+        centros: [
+            { centroId: 1, rolEnCentro: 'PROFESOR' },
+            { centroId: 2, rolEnCentro: 'PROFESOR' }
+        ]
+    },
+    'estudiante@test.com': {
+        id: 4,
+        nombre: 'Estudiante',
+        email: 'estudiante@test.com',
+        password: 'est123',
+        rol: 'USUARIO',
+        centros: [
+            { centroId: 1, rolEnCentro: 'ESTUDIANTE' }
+        ]
+    },
+    'observador@test.com': {
+        id: 5,
+        nombre: 'Observador',
+        email: 'observador@test.com',
+        password: 'obs123',
+        rol: 'USUARIO',
+        centros: [
+            { centroId: 1, rolEnCentro: 'OBSERVADOR' }
+        ]
+    },
+    'nuevo@test.com': {
+        id: 6,
+        nombre: 'Nuevo',
+        email: 'nuevo@test.com',
+        password: 'nuevo123',
+        rol: 'USUARIO',
+        centros: []
+    }
+}
+
 export const AuthProvider = ({ children }) => {
     const [user, setUser] = useState(null);
     const [loading, setLoading] = useState(true);
@@ -28,24 +89,30 @@ export const AuthProvider = ({ children }) => {
         setLoading(false);
     }, []);
 
-    // Login mock - guarda usuario en localStorage
+    // Login mock - guarda usuario (sin contraseña) en localStorage
     const login = (email, password) => {
-        // Validación básica mock
         if (!email || !password) {
             throw new Error('Email y contraseña son requeridos');
         }
+        const mockUser = MOCK_USERS[email];
+        if (!mockUser) {
+            throw new Error('Usuario o contraseña incorrecta');
+        }
+        if (mockUser.password !== password) {
+            throw new Error('Usuario o contraseña incorrecta');
+        }
 
-        // Simular usuario (en producción esto vendría del backend)
-        const mockUser = {
-            id: 1,
-            nombre: email.split('@')[0],
-            email: email,
-            rol: 'ADMIN', // Mock: siempre admin
+        // Crear objeto sin password y guardar (seguridad)
+        const userToSave = {
+            id: mockUser.id,
+            nombre: mockUser.nombre,
+            email: mockUser.email,
+            rol: mockUser.rol,
+            centros: mockUser.centros
         };
-
-        localStorage.setItem('user', JSON.stringify(mockUser));
-        setUser(mockUser);
-        return mockUser;
+        localStorage.setItem('user', JSON.stringify(userToSave));
+        setUser(userToSave);
+        return userToSave;
     };
 
     // Logout - elimina usuario del localStorage
@@ -65,7 +132,8 @@ export const AuthProvider = ({ children }) => {
             id: Date.now(),
             nombre: nombre,
             email: email,
-            rol: 'PROFESOR', // Mock: nuevos usuarios son profesores
+            rol: 'USUARIO',
+            centros: []
         };
 
         localStorage.setItem('user', JSON.stringify(mockUser));


### PR DESCRIPTION
## Summary
- Añade usuarios mock con diferentes combinaciones de roles
- Actualiza login para autenticar contra usuarios mock
- Actualiza register para crear usuarios con rol USUARIO y centros vacío
- Estructura de usuario incluye array centros para control de acceso

## Usuarios mock incluidos
| Email | Rol Global | Centros |
|-------|------------|---------|
| admin@test.com | ADMIN | - |
| coordinador@test.com | USUARIO | Centro 1: COORDINADOR |
| profesor@test.com | USUARIO | Centro 1 y 2: PROFESOR |
| estudiante@test.com | USUARIO | Centro 1: ESTUDIANTE |
| observador@test.com | USUARIO | Centro 1: OBSERVADOR |
| nuevo@test.com | USUARIO | Ninguno |

## Test plan
- [ ] Login con admin@test.com / admin123
- [ ] Login con profesor@test.com / prof123
- [ ] Registro crea usuario con rol USUARIO y centros vacío