### PR TITLE
fix(backend): make migrate_roles.sql idempotent

### DIFF
--- a/backend/migrate_roles.sql
+++ b/backend/migrate_roles.sql
@@ -4,11 +4,14 @@
 -- Ejecutar sobre BD existentes con el esquema antiguo
 -- ============================================
 
--- 1. Actualizar rol de usuario: USUARIO → COORDINADOR
-ALTER TABLE usuario DROP CONSTRAINT chk_usuario_rol;
+-- 1. Limpiar CHECK constraints de la tabla usuario
+ALTER TABLE usuario DROP CONSTRAINT IF EXISTS chk_usuario_rol;
+ALTER TABLE usuario DROP CONSTRAINT IF EXISTS usuario_rol_check;
+
+-- 2. Actualizar rol de usuario: USUARIO → COORDINADOR
 UPDATE usuario SET rol = 'COORDINADOR' WHERE rol = 'USUARIO';
 ALTER TABLE usuario ADD CONSTRAINT chk_usuario_rol CHECK (rol IN ('ADMIN', 'COORDINADOR'));
 
--- 2. Eliminar columna rol_en_centro de usuario_centro
-ALTER TABLE usuario_centro DROP CONSTRAINT chk_usuario_centro_rol;
-ALTER TABLE usuario_centro DROP COLUMN rol_en_centro;
+-- 3. Eliminar columna rol_en_centro de usuario_centro
+ALTER TABLE usuario_centro DROP CONSTRAINT IF EXISTS chk_usuario_centro_rol;
+ALTER TABLE usuario_centro DROP COLUMN IF EXISTS rol_en_centro;


### PR DESCRIPTION
## Summary
- Drop stale `usuario_rol_check` constraint generated by Hibernate that blocked `COORDINADOR` inserts
- Use `IF EXISTS` on all `DROP` statements so the script can run multiple times safely

## Test plan
- [x] Manual: verified constraint was blocking `POST /api/usuarios` with `COORDINADOR` role
- [x] Manual: after fix, all CRUD endpoints work correctly