### PR TITLE
feat(frontend): add permission checks to árboles pages

### DIFF
--- a/frontend/src/pages/arboles/DetalleArbol.jsx
+++ b/frontend/src/pages/arboles/DetalleArbol.jsx
@@ -4,6 +4,7 @@
   import Button from '../../components/common/Button';
   import Spinner from '../../components/common/Spinner';
   import Alert from '../../components/common/Alert';
+  import { usePermissions } from '../../hooks/usePermissions';
 
   function DetalleArbol() {
     const { id } = useParams();
@@ -14,6 +15,7 @@
     const [error, setError] = useState('');
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
     const [deleting, setDeleting] = useState(false);
+    const { canEditArbol, canDeleteArbol } = usePermissions();
 
     useEffect(() => {
       cargarArbol();
@@ -121,16 +123,20 @@
             <Button variant="outline" onClick={handleVolver}>
               Volver
             </Button>
-            <Button variant="primary" onClick={handleEditar}>
-              Editar
-            </Button>
-            <Button 
-              variant="danger" 
-              onClick={() => setShowDeleteConfirm(true)}
-              disabled={deleting}
-            >
-              Eliminar
-            </Button>
+            {canEditArbol(arbol.centroEducativo?.id) && (
+              <Button variant="primary" onClick={handleEditar}>
+                Editar
+              </Button>
+            )}
+            {canDeleteArbol(arbol.centroEducativo?.id) && (
+              <Button
+                variant="danger"
+                onClick={() => setShowDeleteConfirm(true)}
+                disabled={deleting}
+              >
+                Eliminar
+              </Button>
+            )}
           </div>
         </div>
 

--- a/frontend/src/pages/arboles/FormularioArbol.jsx
+++ b/frontend/src/pages/arboles/FormularioArbol.jsx
@@ -6,6 +6,8 @@
   import Button from '../../components/common/Button';
   import Spinner from '../../components/common/Spinner';
   import Alert from '../../components/common/Alert';
+  import { usePermissions } from '../../hooks/usePermissions';
+  import { useAuth } from '../../context/AuthContext';
 
   function FormularioArbol() {
     const { id } = useParams();
@@ -32,6 +34,13 @@
     const [loadingData, setLoadingData] = useState(isEditMode);
     const [error, setError] = useState('');
     const [errors, setErrors] = useState({});
+    const { isAdmin } = usePermissions();
+    const { user } = useAuth();
+
+    // ADMIN ve todos los centros, COORDINADOR solo los suyos
+    const centrosFiltrados = isAdmin()
+      ? centros
+      : centros.filter(c => user?.centros?.some(uc => uc.centroId === c.id));
 
     // Cargar centros y datos del árbol (si es edición)
     useEffect(() => {
@@ -288,7 +297,7 @@
                     required
                   >
                     <option value="">Selecciona un centro</option>
-                    {centros.map(centro => (
+                    {centrosFiltrados.map(centro => (
                       <option key={centro.id} value={centro.id}>
                         {centro.nombre}
                       </option>


### PR DESCRIPTION
## Summary
- **DetalleArbol**: hide Edit/Delete buttons unless user can manage that tree's centro
- **FormularioArbol**: filter centro dropdown — ADMIN sees all, COORDINADOR only their assigned centros
- Completes Phase 4 of the roles roadmap

## Test plan
- [x] Frontend builds successfully
- [ ] As public (no login): detail page shows no Edit/Delete buttons
- [ ] As COORDINADOR: detail shows Edit/Delete only for trees in assigned centros
- [ ] As COORDINADOR: form dropdown shows only assigned centros
- [ ] As ADMIN: detail always shows Edit/Delete, form shows all centros