### PR TITLE
feat(frontend): add permission checks to centros pages

### DIFF
--- a/frontend/src/pages/centros/DetalleCentro.jsx
+++ b/frontend/src/pages/centros/DetalleCentro.jsx
@@ -4,6 +4,7 @@ import { getCentroById, deleteCentro, getArbolesByCentro } from '../../services/
 import Button from '../../components/common/Button';
 import Spinner from '../../components/common/Spinner';
 import Alert from '../../components/common/Alert';
+import { usePermissions } from '../../hooks/usePermissions';
 
 function DetalleCentro() {
   const { id } = useParams();
@@ -16,6 +17,7 @@ function DetalleCentro() {
   const [error, setError] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const { isAdmin, canManageCenter } = usePermissions();
 
   useEffect(() => {
     cargarCentro();
@@ -154,12 +156,16 @@ function DetalleCentro() {
           <Button onClick={handleVolver} variant="outline">
             Volver
           </Button>
-          <Button onClick={handleEditar} variant="primary">
-            Editar
-          </Button>
-          <Button onClick={() => setShowDeleteModal(true)} variant="danger">
-            Eliminar
-          </Button>
+          {canManageCenter(centro.id) && (
+            <Button onClick={handleEditar} variant="primary">
+              Editar
+            </Button>
+          )}
+          {isAdmin() && (
+            <Button onClick={() => setShowDeleteModal(true)} variant="danger">
+              Eliminar
+            </Button>
+          )}
         </div>
       </div>
 

--- a/frontend/src/pages/centros/ListadoCentros.jsx
+++ b/frontend/src/pages/centros/ListadoCentros.jsx
@@ -4,6 +4,7 @@ import { getCentros } from '../../services/centrosService';
 import Button from '../../components/common/Button';
 import Spinner from '../../components/common/Spinner';
 import Alert from '../../components/common/Alert';
+import { usePermissions } from '../../hooks/usePermissions';
 
 function ListadoCentros() {
   // Estados
@@ -12,6 +13,7 @@ function ListadoCentros() {
   const [error, setError] = useState('');
 
   const navigate = useNavigate();
+  const { isAdmin } = usePermissions();
 
   // Cargar centros al montar el componente
   useEffect(() => {
@@ -58,15 +60,16 @@ function ListadoCentros() {
       </div>
 
       {/* Barra de acciones */}
-      <div className="mb-6 flex justify-end">
-        {/* Botón añadir centro */}
-        <Button
-          variant="primary"
-          onClick={handleNuevoCentro}
-        >
-          + Añadir Centro
-        </Button>
-      </div>
+      {isAdmin() && (
+        <div className="mb-6 flex justify-end">
+          <Button
+            variant="primary"
+            onClick={handleNuevoCentro}
+          >
+            + Añadir Centro
+          </Button>
+        </div>
+      )}
 
       {/* Mensaje de error */}
       {error && (


### PR DESCRIPTION
## Summary
- **ListadoCentros**: "Añadir Centro" button visible only for ADMIN
- **DetalleCentro**: Edit button for ADMIN or assigned COORDINADOR, Delete button for ADMIN only
- Completes Phase 5 of the roles roadmap

## Test plan
- [x] Frontend builds successfully
- [ ] As public (no login): no action buttons on list or detail pages
- [ ] As COORDINADOR: Edit visible only on assigned centros, no Delete, no "Añadir Centro"
- [ ] As ADMIN: all buttons visible on all centros