### PR TITLE
Update docs and READMEs for real auth and user management

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -25,8 +25,9 @@ backend/
 │   │   ├── java/
 │   │   │   └── com/example/gardenmonitor/
 │   │   │       ├── GardenmonitorApplication.java  # Clase principal
+│   │   │       ├── config/         # Configuración (CORS, etc.)
 │   │   │       ├── controller/     # Controladores REST
-│   │   │       ├── service/        # Lógica de negocio
+│   │   │       ├── dto/            # DTOs (LoginRequest, RegisterRequest, AuthResponse, etc.)
 │   │   │       ├── repository/     # Repositorios JPA
 │   │   │       └── model/          # Entidades JPA
 │   │   └── resources/
@@ -142,7 +143,7 @@ mvnw.cmd spring-boot:run
 
 El servidor estará disponible en: `http://localhost:8080`
 
-## Endpoints (Requisito PGV Noviembre)
+## Endpoints
 
 ### Centros Educativos
 - `GET /api/centros` - Listar centros
@@ -158,6 +159,23 @@ El servidor estará disponible en: `http://localhost:8080`
 - `POST /api/arboles` - Crear árbol
 - `PUT /api/arboles/{id}` - Actualizar árbol
 - `DELETE /api/arboles/{id}` - Eliminar árbol
+
+### Usuarios
+- `GET /api/usuarios` - Listar todos
+- `GET /api/usuarios/{id}` - Obtener por ID
+- `POST /api/usuarios` - Crear nuevo
+- `PUT /api/usuarios/{id}` - Actualizar
+- `DELETE /api/usuarios/{id}` - Eliminar
+
+### Asignación Usuario-Centro (Relación N:M)
+- `GET /api/usuario-centro/usuario/{usuarioId}` - Centros de un usuario
+- `GET /api/usuario-centro/centro/{centroId}` - Coordinadores de un centro
+- `POST /api/usuario-centro` - Asignar coordinador a centro
+- `DELETE /api/usuario-centro/{id}` - Desasignar coordinador
+
+### Autenticación
+- `POST /api/auth/login` - Login con email y password (valida contra BD)
+- `POST /api/auth/register` - Registro de nuevo usuario (rol COORDINADOR por defecto)
 
 ## Testing
 
@@ -224,10 +242,13 @@ Ver sección "Despliegue en Render" más abajo para detalles completos.
 
 **API REST completada y desplegada en producción**
 
-- [x] 4 Entidades JPA con anotaciones completas, Javadoc y validaciones
+- [x] 6 Entidades JPA con anotaciones completas, Javadoc y validaciones
 - [x] Repositorios JPA con queries derivadas
 - [x] Relaciones bidireccionales (CentroEducativo ↔ Arbol)
-- [x] CRUD completo para Árboles y Centros Educativos
+- [x] Relación N:M (Usuario ↔ CentroEducativo via UsuarioCentro)
+- [x] CRUD completo para Árboles, Centros Educativos y Usuarios
+- [x] Autenticación real contra BD (login/register via AuthController)
+- [x] Sistema de roles (ADMIN, COORDINADOR)
 - [x] Validaciones con Bean Validation
 - [x] Testing Postman completado
 - [x] Desplegado en Render con PostgreSQL 16
@@ -408,7 +429,7 @@ Ver [Manual de Instalación](../docs/MANUAL_DE_INSTALACION.md) para más detalle
 
 **Repositorio**: [github.com/riordi80/vocational-training-final-project](https://github.com/riordi80/vocational-training-final-project)
 
-**Última actualización**: 2025-12-08
+**Última actualización**: 2026-02-14
 
 ### Colaboradores
 

--- a/docs/00. INDICE.md
+++ b/docs/00. INDICE.md
@@ -4,11 +4,14 @@
 
 - [Git Workflow](./01.%20GIT_WORKFLOW.md) - Guía completa de flujo de trabajo con feature branches
 - [Hoja de Ruta](./02.%20HOJA_DE_RUTA.md) - Planificación completa del proyecto por fases
+- [Hoja de Ruta Roles](./02b.%20HOJA_RUTA_ROLES.md) - Sistema de roles, permisos y autenticación
 - [Especificación Técnica](./03.%20ESPECIFICACION_TECNICA.md) - Requisitos y arquitectura del sistema
 - [Modelo de Datos](./04.%20MODELO_DATOS.md) - Diagramas E/R, UML y Relacional completos
 - [Configuración PostgreSQL](./04b.%20CONFIGURACION_POSTGRESQL.md) - Guía de instalación de BD
 - [Requisitos Académicos](./REQUISITOS.md) - Requisitos por módulo (PGV, DAD, AED, PGL)
+- [Roadmap IoT ESP32](./05.%20ROADMAP_IOT_ESP32.md) - Integración de dispositivos ESP32
 - [Testing Postman](./TESTING_POSTMAN_RESULTS.md) - Resultados de pruebas de endpoints REST
+- [Backlog](./BACKLOG.md) - Mejoras futuras pendientes
 
 ## README por Componente
 
@@ -43,10 +46,13 @@ docs/
 ├── 00. INDICE.md                        # Este archivo
 ├── 01. GIT_WORKFLOW.md                  # Flujo de trabajo Git
 ├── 02. HOJA_DE_RUTA.md                  # Planificación por fases
+├── 02b. HOJA_RUTA_ROLES.md             # Sistema de roles y autenticación
 ├── 03. ESPECIFICACION_TECNICA.md        # Arquitectura y requisitos
 ├── 04. MODELO_DATOS.md                  # Diagramas E/R, UML, Relacional
 ├── 04b. CONFIGURACION_POSTGRESQL.md     # Instalación PostgreSQL
 ├── REQUISITOS.md                        # Requisitos académicos
+├── 05. ROADMAP_IOT_ESP32.md             # Integración ESP32
+├── BACKLOG.md                           # Mejoras futuras pendientes
 ├── TESTING_POSTMAN_RESULTS.md           # Resultados testing API REST
 ├── MANUAL_DE_INSTALACION.md             # Manual instalación completo
 ├── MANUAL_DE_USUARIO.md                 # Manual de usuario web/móvil
@@ -76,7 +82,7 @@ docs/
 
 **Repositorio**: [github.com/riordi80/vocational-training-final-project](https://github.com/riordi80/vocational-training-final-project)
 
-**Última actualización**: 2025-12-08
+**Última actualización**: 2026-02-14
 
 ### Colaboradores
 

--- a/docs/02. HOJA_DE_RUTA.md
+++ b/docs/02. HOJA_DE_RUTA.md
@@ -1,7 +1,7 @@
 # Hoja de Ruta - Proyecto Árboles
 
-**Última actualización**: 2026-01-21
-**Estado**: [x] Fase 1 COMPLETADA | [x] Fase 2 COMPLETADA | [x] Fase 3 COMPLETADA | [x] Fase 4 COMPLETADA | [x] Fase 5 COMPLETADA | [x] DESPLIEGUE COMPLETADO | [x] Fase 6 COMPLETADA
+**Última actualización**: 2026-02-14
+**Estado**: [x] Fase 1-6 COMPLETADAS | [x] DESPLIEGUE COMPLETADO | [x] Fase 7 COMPLETADA
 
  **DEADLINE: 8 DE DICIEMBRE 2025** 
 
@@ -42,7 +42,7 @@
 - [x] Desplegar en Vercel (COMPLETADO - https://vocational-training-final-project.vercel.app/)
 - [x] Navegación dinámica
 - [x] Gestión de CRUD establecidos (Árboles completo)
-- [x] Establecer roles (mock básico implementado)
+- [x] Establecer roles (auth real contra BD con endpoints /api/auth)
 - [x] Feedback al usuario (mensajes éxito/error, componentes Alert)
 
 ---
@@ -149,7 +149,7 @@
 
 - [x] **3.4** Context de autenticación [x] COMPLETO
   - [x] AuthContext.jsx
-  - [x] Gestión de roles (mock)
+  - [x] Gestión de roles (auth real contra BD — mocks eliminados)
   - [x] Persistencia con localStorage
 
 - [x] **3.5** Layout responsive [x] COMPLETO
@@ -334,11 +334,13 @@
 
 ## [ ] OPCIONAL (después del 8 dic)
 
-### Fase 7: Endpoints N:M
-- Usuario ↔ CentroEducativo
-- GET, POST, PUT, DELETE
-- [ ] Implementar sistema de roles simplificado (ADMIN + COORDINADOR + acceso público) - ver 02b. HOJA_RUTA_ROLES.md
-- [ ] Eliminar filtrado temporal de permisos en frontend cuando el backend tenga roles
+### Fase 7: Endpoints N:M + Roles + Auth real [x] COMPLETADA
+- [x] Usuario ↔ CentroEducativo (GET, POST, DELETE)
+- [x] Sistema de roles simplificado (ADMIN + COORDINADOR + acceso público) — ver [02b. HOJA_RUTA_ROLES.md](./02b.%20HOJA_RUTA_ROLES.md)
+- [x] Gestión de usuarios (CRUD + asignación de centros, solo ADMIN)
+- [x] Auth real contra BD: `POST /api/auth/login`, `POST /api/auth/register` (AuthController + DTOs)
+- [x] Eliminados mocks de AuthContext — login y registro usan API real
+- [ ] Pendiente: JWT (tokens + BCrypt) — ver notas en 02b
 
 ### Fase 8: Mejoras
 - Sistema lecturas TimescaleDB
@@ -357,7 +359,7 @@
 
 **Repositorio**: [github.com/riordi80/vocational-training-final-project](https://github.com/riordi80/vocational-training-final-project)
 
-**Última actualización**: 2026-01-21
+**Última actualización**: 2026-02-14
 
 ### Colaboradores
 

--- a/docs/02b. HOJA_RUTA_ROLES.md
+++ b/docs/02b. HOJA_RUTA_ROLES.md
@@ -1,7 +1,7 @@
 # Sistema de Roles y Permisos
 
-**Fecha**: 2026-02-13
-**Estado**: Frontend y Backend implementados (pendiente: paginas de arboles/centros, gestion de usuarios)
+**Fecha**: 2026-02-14
+**Estado**: COMPLETADO — Frontend y Backend implementados con auth real contra BD
 **Objetivo**: Simplificar el sistema de acceso a 3 niveles: Admin, Coordinador y Público
 
 ---
@@ -131,12 +131,12 @@ Script de migracion: `backend/migrate_roles.sql` (idempotente con `IF EXISTS`).
 
 ## Usuarios de Prueba
 
-Solo se necesitan 2 usuarios mock (el acceso publico no requiere cuenta):
+Los usuarios se almacenan en la BD. Login y registro se realizan contra la API real (`POST /api/auth/login`, `POST /api/auth/register`). Sin JWT por ahora — la verificacion se hace en el backend pero sin tokens.
 
 | Email | Contrasena | Rol | Centros |
 |-------|------------|-----|---------|
 | admin@test.com | admin123 | ADMIN | Todos (implicito) |
-| coordinador@test.com | coord123 | COORDINADOR | Centro 1 |
+| coordinador@test.com | coord123 | COORDINADOR | Segun tabla `usuario_centro` |
 
 ### admin@test.com
 - **Rol**: ADMIN
@@ -144,8 +144,12 @@ Solo se necesitan 2 usuarios mock (el acceso publico no requiere cuenta):
 
 ### coordinador@test.com
 - **Rol**: COORDINADOR
-- **Centros**: Centro 1
-- **Puede**: CRUD arboles y dispositivos en Centro 1, editar Centro 1
+- **Centros**: Los que tenga asignados en la tabla `usuario_centro`
+- **Puede**: CRUD arboles y dispositivos en sus centros, editar sus centros
+
+### Registro de nuevos usuarios
+- Se registran como COORDINADOR por defecto via `POST /api/auth/register`
+- Sin centros asignados hasta que un ADMIN los asigne
 
 ### Acceso publico (sin cuenta)
 - **Puede**: Ver dashboard, ver todos los centros y arboles, ver detalles
@@ -190,17 +194,7 @@ export const ROLES = { ADMIN: 'ADMIN', COORDINADOR: 'COORDINADOR' };
 
 #### 2.1 Simplificar `src/context/AuthContext.jsx`
 ```javascript
-// Antes: usuario con centros y rolEnCentro
-const user = {
-  id: 1, nombre: 'Juan', email: 'juan@test.com',
-  rol: 'USUARIO',
-  centros: [
-    { centroId: 1, rolEnCentro: 'COORDINADOR' },
-    { centroId: 2, rolEnCentro: 'PROFESOR' }
-  ]
-};
-
-// Despues: usuario con centros (sin rolEnCentro)
+// Estructura del objeto user (devuelta por AuthResponse del backend):
 const user = {
   id: 2, nombre: 'Maria', email: 'coordinador@test.com',
   rol: 'COORDINADOR',
@@ -208,9 +202,11 @@ const user = {
 };
 ```
 
-#### 2.2 Reducir usuarios mock
-- Solo 2: admin@test.com y coordinador@test.com
-- Eliminar: profesor, estudiante, observador, nuevo
+#### 2.2 Auth real contra BD (eliminados mocks)
+- `login(email, password)` → `POST /api/auth/login`
+- `register(nombre, email, password)` → `POST /api/auth/register`
+- Eliminado `MOCK_USERS` completamente
+- Los centros del usuario se cargan de la tabla `usuario_centro` al hacer login
 
 #### 2.3 Permitir navegacion sin login
 - El estado `user: null` ya no redirige al login
@@ -230,7 +226,7 @@ const user = {
 
 ---
 
-### Fase 4: Paginas de arboles (PENDIENTE)
+### Fase 4: Paginas de arboles (COMPLETADA)
 
 #### 4.1 ListadoArboles.jsx
 - Visible para todos (publico incluido)
@@ -247,7 +243,7 @@ const user = {
 
 ---
 
-### Fase 5: Paginas de centros (PENDIENTE)
+### Fase 5: Paginas de centros (COMPLETADA)
 
 #### 5.1 ListadoCentros.jsx
 - Visible para todos
@@ -263,11 +259,12 @@ const user = {
 
 ---
 
-### Fase 6: Gestion de usuarios (PENDIENTE)
+### Fase 6: Gestion de usuarios (COMPLETADA)
 
 - Solo ADMIN puede ver/gestionar usuarios globalmente
-- Pagina para asignar coordinadores a centros
-- No hay roles de centro que asignar, solo la asignacion misma
+- Paginas implementadas: ListadoUsuarios, DetalleUsuario, FormularioUsuario
+- Asignacion/desasignacion de coordinadores a centros desde DetalleUsuario
+- Servicios: `usuariosService.js`, `usuarioCentroService.js`
 
 ---
 
@@ -291,7 +288,7 @@ const user = {
 | `src/constants/roles.js` | Solo ADMIN y COORDINADOR, eliminar ROLES_CENTRO |
 | `src/utils/permissions.js` | Simplificar funciones, eliminar roles de centro |
 | `src/hooks/usePermissions.js` | Adaptar al nuevo modelo |
-| `src/context/AuthContext.jsx` | 2 mock users, permitir navegacion sin login |
+| `src/context/AuthContext.jsx` | Auth real contra BD (mocks eliminados), permitir navegacion sin login |
 | `src/routes/ProtectedRoute.jsx` | Rutas publicas por defecto, proteger solo escritura |
 | `src/components/auth/RoleGate.jsx` | Simplificar (solo ADMIN/COORDINADOR) |
 | `src/layout/Header.jsx` | Adaptar navegacion para usuarios no autenticados |
@@ -311,12 +308,13 @@ Ver `backend/migrate_roles.sql` — script idempotente que:
 
 ## Notas para Futuro (JWT)
 
-Cuando se implemente JWT:
-1. El token contendra `{ id, email, rol, centros: [centroId1, centroId2] }`
-2. Solo cambia como se obtiene el usuario (decodificar token)
-3. Toda la logica de permisos permanece igual
-4. El backend validara permisos tambien (doble verificacion)
-5. Los usuarios no autenticados simplemente no tendran token
+Estado actual: login/registro funcionan contra la BD real. La verificacion de credenciales se hace en el backend pero sin tokens. Cuando se implemente JWT:
+1. Añadir generacion de token en `AuthController.login` y `.register`
+2. Añadir verificacion de token en un filtro/interceptor
+3. El token contendra `{ id, email, rol, centros: [centroId1, centroId2] }`
+4. Reemplazar comparacion de password en texto plano por BCrypt
+5. Toda la logica de permisos permanece igual
+6. Los usuarios no autenticados simplemente no tendran token
 
 ---
 
@@ -330,7 +328,7 @@ Cuando se implemente JWT:
 
 **Repositorio**: [github.com/riordi80/vocational-training-final-project](https://github.com/riordi80/vocational-training-final-project)
 
-**Ultima actualizacion**: 2026-02-13
+**Ultima actualizacion**: 2026-02-14
 
 ### Colaboradores
 

--- a/docs/03. ESPECIFICACION_TECNICA.md
+++ b/docs/03. ESPECIFICACION_TECNICA.md
@@ -125,6 +125,23 @@ graph TB
 - `GET /api/arboles/especie/{especie}` - Filtrar por especie
 - `GET /api/arboles/search?nombre={nombre}` - Búsqueda por nombre
 
+**Usuarios** (`/api/usuarios`):
+- `GET /api/usuarios` - Listar todos
+- `GET /api/usuarios/{id}` - Obtener por ID
+- `POST /api/usuarios` - Crear nuevo
+- `PUT /api/usuarios/{id}` - Actualizar
+- `DELETE /api/usuarios/{id}` - Eliminar
+
+**Asignación Usuario-Centro** (`/api/usuario-centro`):
+- `GET /api/usuario-centro/usuario/{usuarioId}` - Centros de un usuario
+- `GET /api/usuario-centro/centro/{centroId}` - Coordinadores de un centro
+- `POST /api/usuario-centro` - Asignar coordinador a centro
+- `DELETE /api/usuario-centro/{id}` - Desasignar coordinador
+
+**Autenticación** (`/api/auth`):
+- `POST /api/auth/login` - Login con email y password (valida contra BD)
+- `POST /api/auth/register` - Registro de nuevo usuario (rol COORDINADOR por defecto)
+
 **Dispositivos ESP32** (`/api/dispositivos`):
 - CRUD completo de dispositivos IoT
 - Asociación con árboles
@@ -461,13 +478,13 @@ El backend en Render free tier entra en suspensión tras 15 minutos de inactivid
 
 ### 7.2 Frontend
 
-- **Autenticación**: Mock (localStorage) - Nota: No usar en producción real
+- **Autenticación**: Login y registro contra API real (`/api/auth`), sesión en localStorage
 - **XSS**: React escapa automáticamente el contenido
 - **HTTPS**: Forzado por Vercel
 
 ### 7.3 Consideraciones Futuras
 
-- Implementar autenticación real con JWT
+- Implementar JWT (tokens + BCrypt para passwords)
 - Rate limiting en API
 - Encriptación de datos sensibles
 - Auditoría de accesos
@@ -519,7 +536,7 @@ El backend en Render free tier entra en suspensión tras 15 minutos de inactivid
 
 **Repositorio**: [github.com/riordi80/vocational-training-final-project](https://github.com/riordi80/vocational-training-final-project)
 
-**Última actualización**: 2025-12-08
+**Última actualización**: 2026-02-14
 
 ### Colaboradores
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -40,11 +40,14 @@ frontend/
 │   │   │   └── ComponentLibrary.jsx
 │   │   ├── arboles/
 │   │   ├── centros/
+│   │   ├── usuarios/        # Gestión de usuarios (solo ADMIN)
 │   │   └── ...
 │   ├── services/            # Llamadas a API
 │   │   ├── api.js           # Configuración axios
 │   │   ├── arbolesService.js # CRUD completo de árboles
 │   │   ├── centrosService.js # CRUD completo de centros
+│   │   ├── usuariosService.js # CRUD de usuarios (solo ADMIN)
+│   │   ├── usuarioCentroService.js # Asignación usuario-centro
 │   │   └── ...
 │   ├── context/             # Context API para estado global
 │   │   ├── AuthContext.jsx
@@ -122,13 +125,14 @@ npm run lint             # Ejecuta ESLint para verificar código
 
 ### 1. Login (`/login`)
 - Formulario con email y contraseña
-- Mock: guarda en localStorage, redirige a Dashboard
+- Autenticación real contra BD via `POST /api/auth/login`
+- Sesión guardada en localStorage
 - Validación básica
 
 ### 2. Register (`/register`)
 - Formulario de registro
+- Registro real via `POST /api/auth/register` (rol COORDINADOR por defecto)
 - Validación (email válido, contraseñas coinciden)
-- Redirige a Login
 
 ### 3. Dashboard (`/dashboard`)
 - Mensaje de bienvenida
@@ -176,10 +180,10 @@ npm run lint             # Ejecuta ESLint para verificar código
 - Logout limpia localStorage
 
 ### Sistema de Roles
-- Roles globales: ADMIN, USUARIO
-- Roles por centro: COORDINADOR, PROFESOR, ESTUDIANTE, OBSERVADOR
-- Rutas protegidas según rol global y rol en centro
-- Funcionalidades restringidas por permisos
+- 2 roles: ADMIN (acceso total), COORDINADOR (gestiona centros asignados)
+- Acceso público sin login para lectura
+- Login requerido solo para operaciones de escritura
+- Gestión de usuarios solo para ADMIN
 
 ### Feedback al Usuario
 - Mensajes de éxito (toast/alert verde)
@@ -197,14 +201,17 @@ npm run lint             # Ejecuta ESLint para verificar código
 - Variables de entorno para API
 - Build optimizado
 
-## Autenticación (Mock)
+## Autenticación
 
-Login mock con localStorage:
+Login y registro reales contra la API del backend:
 
 ```javascript
-// Login.jsx
-localStorage.setItem('user', JSON.stringify({ email, name: 'Usuario' }));
+// AuthContext.jsx
+const response = await api.post('/auth/login', { email, password });
+localStorage.setItem('user', JSON.stringify(response.data));
 ```
+
+El backend devuelve un objeto `AuthResponse` con `{ id, nombre, email, rol, centros }`. Los centros del usuario se cargan de la tabla `usuario_centro` al hacer login.
 
 ## Consumo de API REST
 
@@ -395,7 +402,7 @@ curl https://vocational-training-final-project.vercel.app/
   - [x] Desplegar en Vercel (COMPLETADO - https://vocational-training-final-project.vercel.app/)
   - [x] Navegación dinámica
   - [x] Gestión de CRUD establecidos (Árboles completo: crear, editar, eliminar, listar, detalle)
-  - [x] Establecer roles (mock básico implementado)
+  - [x] Establecer roles (auth real contra BD, 2 roles: ADMIN y COORDINADOR)
   - [x] Feedback al usuario (componentes Alert, Spinner, modales de confirmación)
 
 ## Plugins de Vite
@@ -408,13 +415,17 @@ Este proyecto usa:
 
 **Aplicación completada y desplegada en producción**
 
-- [x] Servicios API implementados (arbolesService, centrosService)
+- [x] Servicios API implementados (arbolesService, centrosService, usuariosService, usuarioCentroService)
 - [x] Componentes comunes reutilizables (Button, Input, Alert, Spinner)
-- [x] Sistema de autenticación mock con Context API
+- [x] Autenticación real contra BD via AuthContext (login/register con API)
+- [x] Sistema de roles y permisos (ADMIN, COORDINADOR, acceso público)
 - [x] CRUD completo de árboles:
   - ListadoArboles (listar, filtrar, buscar)
   - DetalleArbol (ver detalles completos)
   - FormularioArbol (crear y editar)
+- [x] Gestión de usuarios (solo ADMIN):
+  - ListadoUsuarios, DetalleUsuario, FormularioUsuario
+  - Asignación/desasignación de coordinadores a centros
 - [x] Diseño responsive con Tailwind CSS
 - [x] Menú hamburguesa para móvil
 - [x] React Router configurado
@@ -444,7 +455,7 @@ Este proyecto usa:
 
 **Repositorio**: [github.com/riordi80/vocational-training-final-project](https://github.com/riordi80/vocational-training-final-project)
 
-**Última actualización**: 2025-12-08
+**Última actualización**: 2026-02-14
 
 ### Colaboradores
 


### PR DESCRIPTION
## Summary
- Update roadmaps (02, 02b) to mark roles phases 4-6 as completed and document auth endpoints
- Update backend README with new endpoints (usuarios, usuario-centro, auth) and project structure
- Update frontend README to replace mock auth references with real API auth, add user management pages
- Update technical spec (03) with auth endpoints and security section
- Update index (00) with missing document references (02b, 05, BACKLOG)

## Test plan
- [ ] Verify all markdown links resolve correctly
- [ ] Review accuracy of documented endpoints against actual API