### PR TITLE
docs(git-workflow): enforce feature-to-develop PR policy

### DIFF
--- a/docs/01. GIT_WORKFLOW.md
+++ b/docs/01. GIT_WORKFLOW.md
@@ -5,9 +5,12 @@ Flujo de trabajo con feature branches para el proyecto Garden Monitor.
 ## Reglas de Oro
 
 1. **SIEMPRE** hacer `git pull origin develop` antes de crear una feature branch
-2. **NUNCA** hacer commits directamente en `develop` (solo mediante PRs)
+2. **NUNCA** hacer commits directamente en `develop` o `main` (solo mediante PRs)
 3. **SIEMPRE** trabajar en feature branches
 4. Usar nombres descriptivos para las ramas: `feature/nombre-descriptivo`
+5. **Los PRs de feature branches van SIEMPRE a `develop`, NUNCA directamente a `main`**
+
+> **¿Por qué?** `main` tiene una GitHub Action que bloquea merges de cualquier rama que no sea `develop`. El único camino válido hacia `main` es: `feature/*` → `develop` → `main`. Usar `--admin` para saltarse esta protección está **prohibido**.
 
 
 
@@ -64,11 +67,13 @@ git push -u origin feature/nombre-descriptivo
 
 1. Ve a GitHub: https://github.com/riordi80/vocational-training-final-project
 2. Verás un mensaje: "Compare & pull request"
-3. Selecciona: `feature/nombre-descriptivo` → `develop`
+3. Selecciona: `feature/nombre-descriptivo` → **`develop`**
 4. Añade descripción del PR
 5. Crea el Pull Request
 6. Revisa los cambios
 7. **Merge** el PR (botón verde "Merge pull request")
+
+> ⚠️ **IMPORTANTE**: el campo *base* del PR debe ser siempre **`develop`**. Si GitHub sugiere `main` como base, cámbialo manualmente antes de crear el PR. Un PR apuntando a `main` será bloqueado por la GitHub Action de protección de rama.
 
 ### 6. Actualizar `develop` local después del merge
 
@@ -207,6 +212,28 @@ git checkout feature/nombre-descriptivo
 git stash pop
 ```
 
+### Caso 5: Creé el PR apuntando a `main` en vez de a `develop`
+
+La GitHub Action bloqueará el merge con el mensaje:
+```
+X Pull request is not mergeable: the base branch policy prohibits the merge.
+```
+
+Solución:
+```bash
+# 1. Cerrar el PR incorrecto en GitHub (botón "Close pull request")
+
+# 2. Crear un nuevo PR correctamente desde la misma rama
+gh pr create --base develop --head feature/nombre-descriptivo --title "..." --body "..."
+
+# 3. Hacer merge del PR correcto
+gh pr merge <número> --merge --delete-branch
+```
+
+> **NUNCA** usar `--admin` para saltarse el bloqueo. La protección existe por diseño.
+
+---
+
 ### Caso 4: Me equivoqué y commitee en `develop` en vez de en una feature branch
 
 ```bash
@@ -235,7 +262,7 @@ git push origin feature/nombre-descriptivo
 
 **Repositorio**: [github.com/riordi80/vocational-training-final-project](https://github.com/riordi80/vocational-training-final-project)
 
-**Última actualización**: 2025-12-08
+**Última actualización**: 2026-02-19
 
 ### Colaboradores
 


### PR DESCRIPTION
## Summary

- Add rule 5 to Reglas de Oro: PRs from feature branches always target `develop`, never `main`
- Add explanation of the GitHub Actions protection blocking direct merges to `main`
- Add warning in step 5 (Crear Pull Request) to always verify base branch is `develop`
- Add Caso 5: correct procedure when a PR is accidentally created targeting `main` (close it, reopen with correct base — never use `--admin`)
- Update last-modified date to 2026-02-19

## Test plan

- [ ] Rules of Gold section contains the new rule 5
- [ ] Step 5 has the warning about base branch
- [ ] Caso 5 documents the correct recovery procedure