### PR TITLE
docs: update README and roadmap to reflect current project state

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -171,6 +171,7 @@ El servidor estará disponible en: `http://localhost:8080`
 - `GET /api/usuario-centro/usuario/{usuarioId}` - Centros de un usuario
 - `GET /api/usuario-centro/centro/{centroId}` - Coordinadores de un centro
 - `POST /api/usuario-centro` - Asignar coordinador a centro
+- `PUT /api/usuario-centro/{id}` - Actualizar asignación (usuarioId, centroId, activo)
 - `DELETE /api/usuario-centro/{id}` - Desasignar coordinador
 
 ### Lecturas IoT
@@ -178,6 +179,33 @@ El servidor estará disponible en: `http://localhost:8080`
 - `GET /api/lecturas/arbol/{id}/ultima` - Obtener la última lectura del árbol
 - `GET /api/lecturas/arbol/{id}/grafica?periodo={DIA|SEMANA|MES|SEMESTRE|ANIO}` - Stride sampling: hasta 400 lecturas reales del rango, sin promedios
 - `POST /api/lecturas` - Crear lectura (usado por el firmware ESP32)
+
+### Dispositivos ESP32
+- `GET /api/dispositivos` - Listar todos los dispositivos
+- `GET /api/dispositivos/{id}` - Obtener dispositivo
+- `GET /api/dispositivos/activos` - Listar dispositivos activos
+- `POST /api/dispositivos` - Registrar dispositivo (valida MAC única)
+- `PUT /api/dispositivos/{id}` - Actualizar dispositivo
+- `DELETE /api/dispositivos/{id}` - Eliminar dispositivo
+
+### Alertas
+- `GET /api/alertas` - Listar todas las alertas
+- `GET /api/alertas/{id}` - Obtener alerta
+- `GET /api/alertas/arbol/{arbolId}` - Alertas de un árbol
+- `GET /api/alertas/estado/{estado}` - Alertas por estado (ACTIVA, RESUELTA, IGNORADA)
+- `GET /api/alertas/arbol/{arbolId}/estado/{estado}` - Alertas de un árbol por estado
+- `POST /api/alertas` - Crear alerta
+- `PUT /api/alertas/{id}` - Actualizar alerta (tipo, mensaje, estado, fechaResolucion)
+- `DELETE /api/alertas/{id}` - Eliminar alerta
+
+### Notificaciones
+- `GET /api/notificaciones` - Listar todas las notificaciones
+- `GET /api/notificaciones/{id}` - Obtener notificación
+- `GET /api/notificaciones/usuario/{usuarioId}` - Notificaciones de un usuario
+- `GET /api/notificaciones/usuario/{usuarioId}/no-leidas` - Notificaciones no leídas de un usuario
+- `POST /api/notificaciones` - Crear notificación (requiere usuarioId y alertaId)
+- `PUT /api/notificaciones/{id}` - Marcar como leída/no leída
+- `DELETE /api/notificaciones/{id}` - Eliminar notificación
 
 ### Autenticación
 - `POST /api/auth/login` - Login con email y password (valida contra BD)
@@ -240,7 +268,7 @@ Ver sección "Despliegue en Render" más abajo para detalles completos.
 
 ### [AED] Acceso a Datos
 - [x] Modelo de datos documentado
-- [x] Mapeo ORM con JPA completado (4 entidades JPA)
+- [x] Mapeo ORM con JPA completado (8 entidades JPA)
 - [x] Repositorios JPA con queries derivadas
 - [x] Relaciones bidireccionales implementadas
 
@@ -248,7 +276,7 @@ Ver sección "Despliegue en Render" más abajo para detalles completos.
 
 **API REST completada y desplegada en producción**
 
-- [x] 6 Entidades JPA con anotaciones completas, Javadoc y validaciones
+- [x] 8 Entidades JPA con anotaciones completas, Javadoc y validaciones
 - [x] Repositorios JPA con queries derivadas
 - [x] Relaciones bidireccionales (CentroEducativo ↔ Arbol)
 - [x] Relación N:M (Usuario ↔ CentroEducativo via UsuarioCentro)
@@ -435,7 +463,7 @@ Ver [Manual de Instalación](../docs/MANUAL_DE_INSTALACION.md) para más detalle
 
 **Repositorio**: [github.com/riordi80/vocational-training-final-project](https://github.com/riordi80/vocational-training-final-project)
 
-**Última actualización**: 2026-02-19
+**Última actualización**: 2026-02-22
 
 ### Colaboradores
 

--- a/docs/02. HOJA_DE_RUTA.md
+++ b/docs/02. HOJA_DE_RUTA.md
@@ -1,7 +1,7 @@
 # Hoja de Ruta - Proyecto Árboles
 
-**Última actualización**: 2026-02-21
-**Estado**: [x] Fase 1-7 COMPLETADAS | [x] DESPLIEGUE COMPLETADO | [x] Fase 9 Testing COMPLETADA | [ ] Fases 10-14 Pendientes 2ª Evaluación
+**Última actualización**: 2026-02-22
+**Estado**: [x] Fase 1-7 COMPLETADAS | [x] DESPLIEGUE COMPLETADO | [x] Fase 9 Testing COMPLETADA | [x] Fase 11 PUT N:M COMPLETADA | [x] Fase 14 CRUD entidades COMPLETADA | [ ] Fases 12-13-15 Pendientes 2ª Evaluación
 
 ---
 
@@ -100,9 +100,9 @@
 - [x] CentroEducativoController (CRUD completo)
 - [x] UsuarioCentroController (GET, POST, DELETE — PUT pendiente)
 - [x] AuthController (login + register)
-- [ ] DispositivoEsp32Controller (CRUD) — **pendiente** (ver Fase 14)
-- [ ] AlertaController (CRUD) — **pendiente** (ver Fase 14)
-- [ ] NotificacionController (CRUD) — **pendiente** (ver Fase 14)
+- [x] DispositivoEsp32Controller (CRUD completo)
+- [x] AlertaController (CRUD completo)
+- [x] NotificacionController (CRUD completo)
 
 ---
 
@@ -536,30 +536,30 @@
 
 ---
 
-### Fase 14: Backend — CRUD Entidades Pendientes [ ] [AED]
+### Fase 14: Backend — CRUD Entidades Pendientes [x] [AED]
 
 > Requisito AED: CRUD para TODAS las entidades de la BD, aunque no tengan interfaz gráfica.
 
-- [ ] **14.1** DispositivoEsp32Controller
-  - [ ] GET /api/dispositivos
-  - [ ] GET /api/dispositivos/{id}
-  - [ ] POST /api/dispositivos
-  - [ ] PUT /api/dispositivos/{id}
-  - [ ] DELETE /api/dispositivos/{id}
+- [x] **14.1** DispositivoEsp32Controller
+  - [x] GET /api/dispositivos
+  - [x] GET /api/dispositivos/{id}
+  - [x] POST /api/dispositivos
+  - [x] PUT /api/dispositivos/{id}
+  - [x] DELETE /api/dispositivos/{id}
 
-- [ ] **14.2** AlertaController
-  - [ ] GET /api/alertas
-  - [ ] GET /api/alertas/{id}
-  - [ ] POST /api/alertas
-  - [ ] PUT /api/alertas/{id}
-  - [ ] DELETE /api/alertas/{id}
+- [x] **14.2** AlertaController
+  - [x] GET /api/alertas
+  - [x] GET /api/alertas/{id}
+  - [x] POST /api/alertas
+  - [x] PUT /api/alertas/{id}
+  - [x] DELETE /api/alertas/{id}
 
-- [ ] **14.3** NotificacionController
-  - [ ] GET /api/notificaciones
-  - [ ] GET /api/notificaciones/{id}
-  - [ ] POST /api/notificaciones
-  - [ ] PUT /api/notificaciones/{id}
-  - [ ] DELETE /api/notificaciones/{id}
+- [x] **14.3** NotificacionController
+  - [x] GET /api/notificaciones
+  - [x] GET /api/notificaciones/{id}
+  - [x] POST /api/notificaciones
+  - [x] PUT /api/notificaciones/{id}
+  - [x] DELETE /api/notificaciones/{id}
 
 ---
 
@@ -573,7 +573,7 @@
 
 **Repositorio**: [github.com/riordi80/vocational-training-final-project](https://github.com/riordi80/vocational-training-final-project)
 
-**Última actualización**: 2026-02-20
+**Última actualización**: 2026-02-22
 
 ### Colaboradores
 


### PR DESCRIPTION
## Summary

- Fix incorrect sensor list in description (pH/water level → CO2/trunk diameter)
- Fix entity count 6→8 in backend/README.md and fix Rol enum incorrectly listed as JPA entity
- Fix "all phases complete" status: phases 10, 12, 13, 15 are still pending
- Add missing completed sections to Estado del Proyecto (Fase 7, Lecturas IoT + ESP32, Fase 11) in correct order
- Add missing endpoints to backend/README.md (Fase 14: dispositivos, alertas, notificaciones + PUT usuario-centro from Fase 11)
- Update frontend folder structure (add hooks, utils, constants, layout, routes)
- Mark Fase 14 checkboxes as complete in HOJA_DE_RUTA.md
- Update last-modified dates to 2026-02-22

## Test plan

- [ ] Review README.md for accuracy against codebase
- [ ] Review backend/README.md endpoints list against controllers
- [ ] Review HOJA_DE_RUTA.md phase checkboxes