### PR TITLE
refactor: remove diametroTronco across all layers

### DIFF
--- a/android/app/src/main/java/com/example/proyectoarboles/dto/LecturaMuestraProjection.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/dto/LecturaMuestraProjection.java
@@ -27,9 +27,6 @@ public class LecturaMuestraProjection {
     @SerializedName("co2")
     private Double co2;  // ppm (puede ser null)
 
-    @SerializedName("diametroTronco")
-    private Double diametroTronco;  // mm (puede ser null)
-
     @SerializedName("luz1")
     private Double luz1;  // % (puede ser null)
 
@@ -75,10 +72,6 @@ public class LecturaMuestraProjection {
         return co2;
     }
 
-    public Double getDiametroTronco() {
-        return diametroTronco;
-    }
-
     public Double getLuz1() {
         return luz1;
     }
@@ -110,10 +103,6 @@ public class LecturaMuestraProjection {
 
     public void setCo2(Double co2) {
         this.co2 = co2;
-    }
-
-    public void setDiametroTronco(Double diametroTronco) {
-        this.diametroTronco = diametroTronco;
     }
 
     public void setLuz1(Double luz1) {

--- a/android/app/src/main/java/com/example/proyectoarboles/model/Lectura.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/model/Lectura.java
@@ -30,9 +30,6 @@ public class Lectura {
     @SerializedName("co2")
     private Double co2;  // En ppm (puede ser null)
 
-    @SerializedName("diametroTronco")
-    private Double diametroTronco;  // En mm (puede ser null)
-
     @SerializedName("luz1")
     private Double luz1;  // En % (puede ser null)
 
@@ -82,10 +79,6 @@ public class Lectura {
         return co2;
     }
 
-    public Double getDiametroTronco() {
-        return diametroTronco;
-    }
-
     public Double getLuz1() {
         return luz1;
     }
@@ -121,10 +114,6 @@ public class Lectura {
 
     public void setCo2(Double co2) {
         this.co2 = co2;
-    }
-
-    public void setDiametroTronco(Double diametroTronco) {
-        this.diametroTronco = diametroTronco;
     }
 
     public void setLuz1(Double luz1) {

--- a/backend/create_database.sql
+++ b/backend/create_database.sql
@@ -115,7 +115,6 @@ CREATE TABLE lectura (
     humedad_suelo DECIMAL(5, 2) NOT NULL,
     -- Sensores opcionales (configuración avanzada)
     co2 DECIMAL(7, 2),                          -- NULL si no tiene sensor CO2
-    diametro_tronco DECIMAL(6, 2),              -- NULL si no tiene dendómetro
     luz1 DECIMAL(5, 2),                         -- NULL si no tiene sensor LDR 1
     luz2 DECIMAL(5, 2),                         -- NULL si no tiene sensor LDR 2
     CONSTRAINT pk_lectura PRIMARY KEY (id, timestamp),
@@ -126,7 +125,6 @@ CREATE TABLE lectura (
     CONSTRAINT chk_humedad_ambiente CHECK (humedad_ambiente BETWEEN 0.00 AND 100.00),
     CONSTRAINT chk_humedad_suelo CHECK (humedad_suelo BETWEEN 0.00 AND 100.00),
     CONSTRAINT chk_co2 CHECK (co2 IS NULL OR co2 BETWEEN 0.00 AND 10000.00),
-    CONSTRAINT chk_diametro_tronco CHECK (diametro_tronco IS NULL OR diametro_tronco BETWEEN 0.00 AND 5000.00),
     CONSTRAINT chk_luz1 CHECK (luz1 IS NULL OR luz1 BETWEEN 0.00 AND 100.00),
     CONSTRAINT chk_luz2 CHECK (luz2 IS NULL OR luz2 BETWEEN 0.00 AND 100.00)
 );

--- a/backend/src/main/java/com/example/gardenmonitor/controller/LecturaController.java
+++ b/backend/src/main/java/com/example/gardenmonitor/controller/LecturaController.java
@@ -88,7 +88,6 @@ public class LecturaController {
         lectura.setHumedadAmbiente(request.getHumedadAmbiente());
         lectura.setHumedadSuelo(request.getHumedadSuelo());
         lectura.setCo2(request.getCo2());
-        lectura.setDiametroTronco(request.getDiametroTronco());
         lectura.setLuz1(request.getLuz1());
         lectura.setLuz2(request.getLuz2());
 

--- a/backend/src/main/java/com/example/gardenmonitor/dto/LecturaMuestraProjection.java
+++ b/backend/src/main/java/com/example/gardenmonitor/dto/LecturaMuestraProjection.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
  * para que el resultado nunca supere ~400 puntos, independientemente del rango.
  *
  * Los nombres de los getters mapean con los alias de la query nativa:
- *   id, timestamp, temperatura, humedad_ambiente, humedad_suelo, co2, diametro_tronco
+ *   id, timestamp, temperatura, humedad_ambiente, humedad_suelo, co2, luz1, luz2
  */
 public interface LecturaMuestraProjection {
 
@@ -24,8 +24,6 @@ public interface LecturaMuestraProjection {
     BigDecimal getHumedadSuelo();
 
     BigDecimal getCo2();
-
-    BigDecimal getDiametroTronco();
 
     BigDecimal getLuz1();
 

--- a/backend/src/main/java/com/example/gardenmonitor/dto/LecturaRequest.java
+++ b/backend/src/main/java/com/example/gardenmonitor/dto/LecturaRequest.java
@@ -43,10 +43,6 @@ public class LecturaRequest {
     private BigDecimal co2;
 
     @DecimalMin(value = "0.00")
-    @DecimalMax(value = "5000.00")
-    private BigDecimal diametroTronco;
-
-    @DecimalMin(value = "0.00")
     @DecimalMax(value = "100.00")
     private BigDecimal luz1;
 
@@ -61,7 +57,6 @@ public class LecturaRequest {
     public BigDecimal getHumedadAmbiente() { return humedadAmbiente; }
     public BigDecimal getHumedadSuelo() { return humedadSuelo; }
     public BigDecimal getCo2() { return co2; }
-    public BigDecimal getDiametroTronco() { return diametroTronco; }
     public BigDecimal getLuz1() { return luz1; }
     public BigDecimal getLuz2() { return luz2; }
 
@@ -70,7 +65,6 @@ public class LecturaRequest {
     public void setHumedadAmbiente(BigDecimal humedadAmbiente) { this.humedadAmbiente = humedadAmbiente; }
     public void setHumedadSuelo(BigDecimal humedadSuelo) { this.humedadSuelo = humedadSuelo; }
     public void setCo2(BigDecimal co2) { this.co2 = co2; }
-    public void setDiametroTronco(BigDecimal diametroTronco) { this.diametroTronco = diametroTronco; }
     public void setLuz1(BigDecimal luz1) { this.luz1 = luz1; }
     public void setLuz2(BigDecimal luz2) { this.luz2 = luz2; }
 }

--- a/backend/src/main/java/com/example/gardenmonitor/model/Lectura.java
+++ b/backend/src/main/java/com/example/gardenmonitor/model/Lectura.java
@@ -99,11 +99,6 @@ public class Lectura {
     private BigDecimal co2;
 
     @DecimalMin(value = "0.00")
-    @DecimalMax(value = "5000.00")
-    @Column(name = "diametro_tronco", precision = 6, scale = 2)
-    private BigDecimal diametroTronco;
-
-    @DecimalMin(value = "0.00")
     @DecimalMax(value = "100.00")
     @Column(name = "luz1", precision = 5, scale = 2)
     private BigDecimal luz1;
@@ -126,7 +121,6 @@ public class Lectura {
     public BigDecimal getHumedadAmbiente() { return humedadAmbiente; }
     public BigDecimal getHumedadSuelo() { return humedadSuelo; }
     public BigDecimal getCo2() { return co2; }
-    public BigDecimal getDiametroTronco() { return diametroTronco; }
     public BigDecimal getLuz1() { return luz1; }
     public BigDecimal getLuz2() { return luz2; }
 
@@ -138,7 +132,6 @@ public class Lectura {
     public void setHumedadAmbiente(BigDecimal humedadAmbiente) { this.humedadAmbiente = humedadAmbiente; }
     public void setHumedadSuelo(BigDecimal humedadSuelo) { this.humedadSuelo = humedadSuelo; }
     public void setCo2(BigDecimal co2) { this.co2 = co2; }
-    public void setDiametroTronco(BigDecimal diametroTronco) { this.diametroTronco = diametroTronco; }
     public void setLuz1(BigDecimal luz1) { this.luz1 = luz1; }
     public void setLuz2(BigDecimal luz2) { this.luz2 = luz2; }
 

--- a/backend/src/main/java/com/example/gardenmonitor/repository/LecturaRepository.java
+++ b/backend/src/main/java/com/example/gardenmonitor/repository/LecturaRepository.java
@@ -42,7 +42,6 @@ public interface LecturaRepository extends JpaRepository<Lectura, Long> {
                        l.humedad_ambiente,
                        l.humedad_suelo,
                        l.co2,
-                       l.diametro_tronco,
                        l.luz1,
                        l.luz2,
                        ROW_NUMBER() OVER (ORDER BY l.timestamp ASC) AS rn,
@@ -53,7 +52,7 @@ public interface LecturaRepository extends JpaRepository<Lectura, Long> {
                   AND l.timestamp <= :hasta
             )
             SELECT id, timestamp, temperatura, humedad_ambiente,
-                   humedad_suelo, co2, diametro_tronco, luz1, luz2
+                   humedad_suelo, co2, luz1, luz2
             FROM numbered
             WHERE MOD(rn - 1, GREATEST(1, CEIL(total_count::float / 400)::int)) = 0
                OR rn = total_count

--- a/docs/04. MODELO_DATOS.md
+++ b/docs/04. MODELO_DATOS.md
@@ -117,7 +117,6 @@ erDiagram
         decimal humedad_ambiente
         decimal humedad_suelo
         decimal co2
-        decimal diametro_tronco
         decimal luz1
         decimal luz2
     }
@@ -255,7 +254,6 @@ classDiagram
         -BigDecimal humedadAmbiente
         -BigDecimal humedadSuelo
         -BigDecimal co2
-        -BigDecimal diametroTronco
         -BigDecimal luz1
         -BigDecimal luz2
         +getId() Long
@@ -264,7 +262,6 @@ classDiagram
         +getHumedadAmbiente() BigDecimal
         +getHumedadSuelo() BigDecimal
         +getCo2() BigDecimal
-        +getDiametroTronco() BigDecimal
         +getLuz1() BigDecimal
         +getLuz2() BigDecimal
     }
@@ -470,7 +467,6 @@ classDiagram
 | `humedad_ambiente` | DECIMAL(5, 2) | NOT NULL | Humedad ambiental (%) |
 | `humedad_suelo` | DECIMAL(5, 2) | NOT NULL | Humedad del suelo (%) |
 | `co2` | DECIMAL(7, 2) | NULL | CO2 ambiental (ppm) - Opcional |
-| `diametro_tronco` | DECIMAL(6, 2) | NULL | Diámetro del tronco (mm) - Opcional |
 | `luz1` | DECIMAL(5, 2) | NULL | Nivel de luz sensor LDR 1 (%) - Opcional |
 | `luz2` | DECIMAL(5, 2) | NULL | Nivel de luz sensor LDR 2 (%) - Opcional |
 
@@ -694,7 +690,6 @@ CREATE TABLE lectura (
     humedad_suelo DECIMAL(5, 2) NOT NULL,
     -- Sensores opcionales (configuración avanzada)
     co2 DECIMAL(7, 2),                          -- NULL si no tiene sensor CO2
-    diametro_tronco DECIMAL(6, 2),              -- NULL si no tiene dendómetro
     luz1 DECIMAL(5, 2),                         -- NULL si no tiene sensor LDR 1
     luz2 DECIMAL(5, 2),                         -- NULL si no tiene sensor LDR 2
     CONSTRAINT pk_lectura PRIMARY KEY (id, timestamp),
@@ -705,7 +700,6 @@ CREATE TABLE lectura (
     CONSTRAINT chk_humedad_ambiente CHECK (humedad_ambiente BETWEEN 0.00 AND 100.00),
     CONSTRAINT chk_humedad_suelo CHECK (humedad_suelo BETWEEN 0.00 AND 100.00),
     CONSTRAINT chk_co2 CHECK (co2 IS NULL OR co2 BETWEEN 0.00 AND 10000.00),
-    CONSTRAINT chk_diametro_tronco CHECK (diametro_tronco IS NULL OR diametro_tronco BETWEEN 0.00 AND 5000.00),
     CONSTRAINT chk_luz1 CHECK (luz1 IS NULL OR luz1 BETWEEN 0.00 AND 100.00),
     CONSTRAINT chk_luz2 CHECK (luz2 IS NULL OR luz2 BETWEEN 0.00 AND 100.00)
 );

--- a/docs/05. ROADMAP_IOT_ESP32.md
+++ b/docs/05. ROADMAP_IOT_ESP32.md
@@ -45,7 +45,6 @@ El ESP32 se identifica ante el backend mediante su **MAC address** (ya modelada 
   "humedadAmbiente": 65.00,
   "humedadSuelo": 45.30,
   "co2": 420,
-  "diametroTronco": null,
   "luz1": 78.00,
   "luz2": 65.00
 }
@@ -54,7 +53,7 @@ El ESP32 se identifica ante el backend mediante su **MAC address** (ya modelada 
 **Notas**:
 - `macAddress`: Obligatorio. Formato `XX:XX:XX:XX:XX:XX`
 - `temperatura`, `humedadAmbiente`, `humedadSuelo`: Obligatorios
-- `co2`, `diametroTronco`, `luz1`, `luz2`: Opcionales (null si no hay sensor)
+- `co2`, `luz1`, `luz2`: Opcionales (null si no hay sensor)
 - El `timestamp` lo asigna el backend al recibir la lectura (evita problemas de sincronización de relojes)
 
 ### 1.4 Respuestas del Backend
@@ -84,7 +83,7 @@ El ESP32 se identifica ante el backend mediante su **MAC address** (ya modelada 
 
 | Sensor | Campo en BD | Estado |
 |--------|-------------|--------|
-| Dendómetro | `diametro_tronco` | Descartado por presupuesto |
+| Dendómetro | — | Descartado. Campo `diametro_tronco` eliminado del modelo |
 
 ---
 

--- a/frontend/src/pages/arboles/HistoricoArbol.jsx
+++ b/frontend/src/pages/arboles/HistoricoArbol.jsx
@@ -312,9 +312,6 @@ function HistoricoArbol() {
                   <th className="px-4 py-3 text-right text-xs font-medium text-white uppercase tracking-wider">
                     Luz 2 (%)
                   </th>
-                  <th className="px-4 py-3 text-right text-xs font-medium text-white uppercase tracking-wider">
-                    Diám. Tronco (mm)
-                  </th>
                 </tr>
               </thead>
               <tbody className="bg-white divide-y divide-brand-bg-green">
@@ -351,11 +348,6 @@ function HistoricoArbol() {
                     <td className="px-4 py-3 text-right text-gray-700">
                       {lectura.luz2 != null
                         ? parseFloat(lectura.luz2).toFixed(1)
-                        : '-'}
-                    </td>
-                    <td className="px-4 py-3 text-right text-gray-700">
-                      {lectura.diametroTronco != null
-                        ? parseFloat(lectura.diametroTronco).toFixed(1)
                         : '-'}
                     </td>
                   </tr>


### PR DESCRIPTION
## Summary

- Remove `diametro_tronco` / `diametroTronco` from all layers of the project
- The dendometer sensor has been discarded from the project scope due to cost and availability

## Changes

**Backend**: remove field from `Lectura` entity, `LecturaRequest` DTO, `LecturaMuestraProjection` interface, `LecturaController` mapping and `LecturaRepository` native query

**Frontend**: remove `Diám. Tronco` column from `HistoricoArbol` table

**Android**: remove field from `Lectura` model and `LecturaMuestraProjection` DTO

**Database**: remove `diametro_tronco` column and its CHECK constraint from `create_database.sql`

**Docs**: remove field from ER diagram, UML class, table definition and SQL in `MODELO_DATOS`. Update JSON example and mark dendometer as discarded in `ROADMAP_IOT_ESP32`

> Note: the column still exists in the production database on Render. A manual `ALTER TABLE lectura DROP COLUMN diametro_tronco` should be executed when convenient. Spring Boot ignores unknown columns so this does not affect functionality.

## Test plan

- [ ] Verify backend compiles without errors
- [ ] Send POST to `/api/lecturas` without `diametroTronco` field and confirm 201 response
- [ ] Confirm HistoricoArbol table no longer shows the Diám. Tronco column
- [ ] Build Android app without errors