### PR TITLE
refactor: rename frecuencia_lectura_min to frecuencia_lectura_seg

### DIFF
--- a/backend/create_database.sql
+++ b/backend/create_database.sql
@@ -58,7 +58,7 @@ CREATE TABLE dispositivo_esp32 (
     arbol_id BIGINT,
     activo BOOLEAN NOT NULL DEFAULT TRUE,
     ultima_conexion TIMESTAMPTZ,
-    frecuencia_lectura_min INTEGER DEFAULT 15,
+    frecuencia_lectura_seg INTEGER DEFAULT 30,
     CONSTRAINT pk_dispositivo_esp32 PRIMARY KEY (id),
     CONSTRAINT uq_dispositivo_mac_address UNIQUE (mac_address)
 );

--- a/backend/src/main/java/com/example/gardenmonitor/model/DispositivoEsp32.java
+++ b/backend/src/main/java/com/example/gardenmonitor/model/DispositivoEsp32.java
@@ -63,14 +63,15 @@ public class DispositivoEsp32 {
     private LocalDateTime ultimaConexion;
 
     /**
-     * Frecuencia de lectura de sensores en minutos.
+     * Frecuencia de lectura de sensores en segundos.
      * <p>
-     * Define cada cuántos minutos el ESP32 debe tomar mediciones.
-     * Por defecto: 15 minutos.
+     * Define cada cuántos segundos el ESP32 debe tomar mediciones.
+     * Por defecto: 30 segundos (fase de prototipo).
+     * En producción: 900 segundos (15 minutos).
      * </p>
      */
-    @Column(name = "frecuencia_lectura_min", columnDefinition = "INTEGER DEFAULT 15")
-    private int frecuenciaLecturaMin;
+    @Column(name = "frecuencia_lectura_seg", columnDefinition = "INTEGER DEFAULT 30")
+    private int frecuenciaLecturaSeg;
 
     /**
      * Constructor vacío requerido por JPA.
@@ -86,13 +87,13 @@ public class DispositivoEsp32 {
      * @param macAddress dirección MAC del dispositivo (formato XX:XX:XX:XX:XX:XX)
      * @param arbol árbol asociado al dispositivo (puede ser null)
      * @param activo indica si el dispositivo está activo
-     * @param frecuenciaLecturaMin frecuencia de lectura en minutos (por defecto 15)
+     * @param frecuenciaLecturaSeg frecuencia de lectura en segundos (por defecto 30)
      */
-    public DispositivoEsp32(String macAddress, Arbol arbol, boolean activo, int frecuenciaLecturaMin) {
+    public DispositivoEsp32(String macAddress, Arbol arbol, boolean activo, int frecuenciaLecturaSeg) {
         this.macAddress = macAddress;
         this.arbol = arbol;
         this.activo = activo;
-        this.frecuenciaLecturaMin = frecuenciaLecturaMin;
+        this.frecuenciaLecturaSeg = frecuenciaLecturaSeg;
     }
 
     public Long getId() {return id;}
@@ -100,14 +101,14 @@ public class DispositivoEsp32 {
     public Arbol getArbol() {return arbol;}
     public boolean isActivo() {return activo;}
     public LocalDateTime getUltimaConexion() {return ultimaConexion;}
-    public int getFrecuenciaLecturaMin() {return frecuenciaLecturaMin;}
+    public int getFrecuenciaLecturaSeg() {return frecuenciaLecturaSeg;}
 
     public void setId(Long id) {this.id = id;}
     public void setMacAddress(String macAddress) {this.macAddress = macAddress;}
     public void setArbol(Arbol arbol) {this.arbol = arbol;}
     public void setActivo(boolean activo) {this.activo = activo;}
     public void setUltimaConexion(LocalDateTime ultimaConexion) {this.ultimaConexion = ultimaConexion;}
-    public void setFrecuenciaLecturaMin(int frecuenciaLecturaMin) {this.frecuenciaLecturaMin = frecuenciaLecturaMin;}
+    public void setFrecuenciaLecturaSeg(int frecuenciaLecturaSeg) {this.frecuenciaLecturaSeg = frecuenciaLecturaSeg;}
 
     /**
      * Callback ejecutado antes de persistir un nuevo dispositivo ESP32 en la base de datos.

--- a/docs/04. MODELO_DATOS.md
+++ b/docs/04. MODELO_DATOS.md
@@ -105,7 +105,7 @@ erDiagram
         bigint arbol_id FK
         boolean activo
         timestamptz ultima_conexion
-        int frecuencia_lectura_min
+        int frecuencia_lectura_seg
     }
 
     LECTURA {
@@ -238,7 +238,7 @@ classDiagram
         -Arbol arbol
         -Boolean activo
         -LocalDateTime ultimaConexion
-        -Integer frecuenciaLecturaMin
+        -Integer frecuenciaLecturaSeg
         -Set~Lectura~ lecturas
         +getId() Long
         +getMacAddress() String
@@ -443,7 +443,7 @@ classDiagram
 | `arbol_id` | BIGINT | NULL, FOREIGN KEY | Árbol asociado |
 | `activo` | BOOLEAN | NOT NULL, DEFAULT TRUE | Dispositivo activo |
 | `ultima_conexion` | TIMESTAMPTZ | NULL | Última vez que envió datos |
-| `frecuencia_lectura_min` | INTEGER | DEFAULT 15 | Intervalo de lecturas (minutos) |
+| `frecuencia_lectura_seg` | INTEGER | DEFAULT 30 | Intervalo de lecturas (segundos) |
 
 **Índices**:
 - PRIMARY KEY en `id`
@@ -633,7 +633,7 @@ CREATE TABLE dispositivo_esp32 (
     arbol_id BIGINT,
     activo BOOLEAN NOT NULL DEFAULT TRUE,
     ultima_conexion TIMESTAMPTZ,
-    frecuencia_lectura_min INTEGER DEFAULT 15,
+    frecuencia_lectura_seg INTEGER DEFAULT 30,
     CONSTRAINT pk_dispositivo_esp32 PRIMARY KEY (id),
     CONSTRAINT uq_dispositivo_mac_address UNIQUE (mac_address)
 );

--- a/docs/05. ROADMAP_IOT_ESP32.md
+++ b/docs/05. ROADMAP_IOT_ESP32.md
@@ -24,7 +24,7 @@ sequenceDiagram
     Backend->>Backend: Obtener arbol_id asociado
     Backend->>DB: INSERT en tabla lectura (hypertable)
     Backend-->>ESP32: 201 Created / 4xx Error
-    ESP32->>ESP32: Esperar frecuencia_lectura_min
+    ESP32->>ESP32: Esperar frecuencia_lectura_seg
 ```
 
 ### 1.2 Identificación del dispositivo
@@ -116,7 +116,7 @@ const char* BACKEND_URL = "http://localhost:8080/api/lecturas";  // Local
 
 ### 3.4 Frecuencia de envío
 
-- Default: 15 minutos (consistente con `frecuencia_lectura_min` en BD)
+- Default: 30 segundos en prototipo, 900 segundos (15 min) en producción (consistente con `frecuencia_lectura_seg` en BD)
 - Para desarrollo/testing: 30 segundos
 - Configurable como constante en el sketch
 


### PR DESCRIPTION
## Summary

- Rename `frecuencia_lectura_min` to `frecuencia_lectura_seg` in all layers to store the reading interval in seconds instead of minutes
- Change default value from 15 (minutes) to 30 (seconds) for the prototype phase
- Apply the migration on both local and production databases

## Changes

**Backend**: rename field, column annotation, getter and setter in `DispositivoEsp32` entity; update `create_database.sql`

**Database**: `ALTER TABLE dispositivo_esp32 RENAME COLUMN frecuencia_lectura_min TO frecuencia_lectura_seg` + default and value updated to 30 on both local and Render

**Docs**: update ER diagram, UML class, table definition, SQL schema in `MODELO_DATOS` and `ROADMAP_IOT_ESP32`

## Test plan

- [ ] Verify backend compiles and starts correctly
- [ ] Check GET `/api/dispositivos` returns `frecuenciaLecturaSeg: 30`
- [ ] Verify PUT `/api/dispositivos/{id}` can update the field