### PR TITLE
feat(frontend): split sensor charts in HistoricoArbol

### DIFF
--- a/frontend/src/pages/arboles/HistoricoArbol.jsx
+++ b/frontend/src/pages/arboles/HistoricoArbol.jsx
@@ -98,6 +98,8 @@ function HistoricoArbol() {
               tiempo: formatTimestampShort(item.timestamp),
               temperatura: item.temperatura != null ? parseFloat(item.temperatura) : null,
               humedadAmbiente: item.humedadAmbiente != null ? parseFloat(item.humedadAmbiente) : null,
+              humedadSuelo: item.humedadSuelo != null ? parseFloat(item.humedadSuelo) : null,
+              co2: item.co2 != null ? parseFloat(item.co2) : null,
               luz1: item.luz1 != null ? parseFloat(item.luz1) : null,
               luz2: item.luz2 != null ? parseFloat(item.luz2) : null,
             }))
@@ -192,7 +194,7 @@ function HistoricoArbol() {
       <div className="bg-white rounded-lg shadow-md p-6 mb-6">
         <div className="flex items-baseline gap-2 mb-1">
           <h2 className="text-lg font-semibold text-gray-800">
-            Temperatura y Humedad Ambiente
+            Temperatura, Humedad y Luz
           </h2>
         </div>
         <p className="text-xs text-gray-500 mb-4">
@@ -242,6 +244,14 @@ function HistoricoArbol() {
               />
               <Line
                 type="monotone"
+                dataKey="humedadSuelo"
+                name="Humedad Suelo (%)"
+                stroke="#22c55e"
+                dot={false}
+                connectNulls
+              />
+              <Line
+                type="monotone"
                 dataKey="luz1"
                 name="Luz 1 (%)"
                 stroke="#eab308"
@@ -253,6 +263,54 @@ function HistoricoArbol() {
                 dataKey="luz2"
                 name="Luz 2 (%)"
                 stroke="#a855f7"
+                dot={false}
+                connectNulls
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      {/* Gráfica CO2 */}
+      <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+        <div className="flex items-baseline gap-2 mb-1">
+          <h2 className="text-lg font-semibold text-gray-800">
+            CO2
+          </h2>
+        </div>
+        <p className="text-xs text-gray-500 mb-4">
+          {periodoConfig.label} · {datosGrafica.filter(d => d.co2 != null).length} lecturas con datos
+        </p>
+
+        {loadingGrafica ? (
+          <div className="flex justify-center py-10">
+            <Spinner size="md" text="Cargando gráfica..." />
+          </div>
+        ) : datosGrafica.filter(d => d.co2 != null).length === 0 ? (
+          <p className="text-center text-gray-400 py-10 text-sm">
+            Sin datos de CO2 en este periodo.
+          </p>
+        ) : (
+          <ResponsiveContainer width="100%" height={200}>
+            <LineChart data={datosGrafica} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis
+                dataKey="tiempo"
+                tick={{ fontSize: 11 }}
+                interval="preserveStartEnd"
+              />
+              <YAxis tick={{ fontSize: 11 }} unit=" ppm" />
+              <Tooltip
+                formatter={(value, name) =>
+                  value != null ? [`${value} ppm`, name] : ['-', name]
+                }
+              />
+              <Legend />
+              <Line
+                type="monotone"
+                dataKey="co2"
+                name="CO2 (ppm)"
+                stroke="#ef4444"
                 dot={false}
                 connectNulls
               />


### PR DESCRIPTION
## Summary

- Rename first chart to "Temperatura, Humedad y Luz" and add all sensor lines
- Add a second independent chart for CO2 with its own ppm scale

## Changes

**Chart 1 — Temperatura, Humedad y Luz**:
- Temperatura (naranja)
- Humedad Ambiente (azul)
- Humedad Suelo (verde) — new
- Luz 1 (amarillo)
- Luz 2 (púrpura)

**Chart 2 — CO2** (new):
- CO2 (rojo, ppm scale)
- Only rendered when CO2 data is available

## Test plan

- [ ] Open HistoricoArbol for a tree with readings and verify both charts render correctly
- [ ] Verify CO2 chart shows "Sin datos" message when there are no CO2 readings
- [ ] Verify all 5 lines appear in chart 1 legend