### PR TITLE
feat(frontend): add automatic polling to HistoricoArbol

### DIFF
--- a/backend/src/main/java/com/example/gardenmonitor/controller/DispositivoEsp32Controller.java
+++ b/backend/src/main/java/com/example/gardenmonitor/controller/DispositivoEsp32Controller.java
@@ -111,7 +111,7 @@ public class DispositivoEsp32Controller {
         dispositivo.setMacAddress(detalles.getMacAddress());
         dispositivo.setActivo(detalles.isActivo());
         dispositivo.setUltimaConexion(detalles.getUltimaConexion());
-        dispositivo.setFrecuenciaLecturaMin(detalles.getFrecuenciaLecturaMin());
+        dispositivo.setFrecuenciaLecturaSeg(detalles.getFrecuenciaLecturaSeg());
 
         return dispositivoRepository.save(dispositivo);
     }

--- a/frontend/src/pages/arboles/HistoricoArbol.jsx
+++ b/frontend/src/pages/arboles/HistoricoArbol.jsx
@@ -63,6 +63,8 @@ function HistoricoArbol() {
 
   const [arbol, setArbol] = useState(null);
   const [error, setError] = useState('');
+  const [intervaloSeg, setIntervaloSeg] = useState(30);
+  const [refreshKey, setRefreshKey] = useState(0);
 
   // Periodo activo (controla tanto la gráfica como la tabla)
   const [periodoActivo, setPeriodoActivo] = useState('SEMANA');
@@ -81,9 +83,21 @@ function HistoricoArbol() {
   // --- Carga del árbol (solo una vez) ---
   useEffect(() => {
     getArbolById(id)
-      .then(setArbol)
+      .then((data) => {
+        setArbol(data);
+        const seg = data?.dispositivoEsp32?.frecuenciaLecturaSeg;
+        if (seg && seg > 0) setIntervaloSeg(seg);
+      })
       .catch(() => setError('No se pudo cargar la información del árbol.'));
   }, [id]);
+
+  // --- Polling: incrementa refreshKey cada intervaloSeg segundos ---
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setRefreshKey((k) => k + 1);
+    }, intervaloSeg * 1000);
+    return () => clearInterval(timer);
+  }, [intervaloSeg]);
 
   // --- Gráfica: recarga cuando cambia el árbol o el periodo ---
   useEffect(() => {
@@ -113,7 +127,7 @@ function HistoricoArbol() {
     };
     fetch();
     return () => { cancelled = true; };
-  }, [id, periodoActivo]);
+  }, [id, periodoActivo, refreshKey]);
 
   // --- Tabla: recarga cuando cambia el árbol, el periodo o la página ---
   useEffect(() => {
@@ -137,7 +151,7 @@ function HistoricoArbol() {
     };
     fetch();
     return () => { cancelled = true; };
-  }, [id, periodoActivo, currentPage]);
+  }, [id, periodoActivo, currentPage, refreshKey]);
 
   // Cuando el usuario cambia de periodo, reseteamos a página 0 en el mismo batch
   const handlePeriodoChange = (key) => {


### PR DESCRIPTION
## Summary

- HistoricoArbol now refreshes automatically without needing a page reload
- Polling interval is read from `dispositivoEsp32.frecuenciaLecturaSeg` (currently 30s), so changing the value in the database automatically adjusts the frontend refresh rate

## How it works

1. On load, `frecuenciaLecturaSeg` is extracted from the árbol response
2. A `setInterval` increments a `refreshKey` state every N seconds
3. Both the chart and table `useEffect` hooks include `refreshKey` in their dependency arrays — they re-fetch automatically on each tick

## Test plan

- [ ] Open HistoricoArbol and wait 30 seconds — verify chart and table update without interaction
- [ ] Confirm no visible flicker or error during auto-refresh
- [ ] Verify polling stops when navigating away (no memory leaks)