### PR TITLE
refactor: device-center model — devices belong to centers, thresholds on device

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Sistema de monitorización y gestión de árboles plantados en centros educativo
 
 ## Descripción
 
-Este proyecto permite recopilar datos ambientales (temperatura, humedad ambiente, humedad del suelo, CO2, luz) a través de dispositivos ESP32 con sensores, y visualizarlos en tiempo real mediante aplicaciones web y móvil. El sistema está diseñado para centros educativos que desean monitorizar el crecimiento y estado de sus árboles.
+Este proyecto permite recopilar datos ambientales (temperatura, humedad ambiente, humedad del suelo, CO2, luz) a través de dispositivos ESP32 con sensores, y visualizarlos en tiempo real mediante aplicaciones web y móvil. El sistema está diseñado para centros educativos que gestionan un inventario de árboles y monitorizan las condiciones ambientales de sus instalaciones mediante dispositivos IoT asignados por centro.
 
 ## Componentes del Proyecto
 
@@ -23,21 +23,23 @@ Este es un **monorepo** que contiene todos los componentes del sistema:
 ### `/backend`
 API REST con **Spring Boot (Java)**
 - CRUD completo para las 8 entidades: centros educativos, árboles, usuarios, dispositivos ESP32, lecturas IoT, alertas, notificaciones y asignación usuario-centro (N:M)
-- Relaciones 1:N y N:M con validaciones
+- Relaciones 1:N y N:M con validaciones; cada dispositivo ESP32 pertenece a un centro educativo
+- Umbrales de monitorización (temperatura, humedad, CO2) configurables por dispositivo; `PATCH /api/dispositivos/{id}/umbrales` para actualización parcial
 - PostgreSQL + TimescaleDB (hypertable para series temporales)
 - Sistema de roles (ADMIN / COORDINADOR) con autenticación real contra BD
 
 ### `/frontend`
 Aplicación web con **React**
 - Login/Register con persistencia (localStorage)
-- Dashboard + CRUD Árboles completo (listar, crear, editar, eliminar, detalle)
+- Dashboard + CRUD Árboles completo (listar, crear, editar, eliminar, detalle) — los árboles actúan como inventario del centro
+- CRUD Dispositivos ESP32 integrado en el detalle de cada centro (listar, crear, editar, eliminar, histórico)
 - React Router + navegación dinámica
 - Responsive con menú hamburguesa (Tailwind CSS)
 - Sistema de roles (ADMIN / COORDINADOR, autenticación real contra BD)
 - Componentes reutilizables (Button, Input, Alert, Spinner)
 - Feedback usuario (mensajes éxito/error, validaciones)
 - Visualización de lecturas IoT con gráficas (Recharts) y mapas (Leaflet): gráfica de sensores 0-100% y gráfica de CO2 (ppm) independiente
-- Polling automático en HistoricoArbol sincronizado con la frecuencia de lectura del dispositivo ESP32
+- Polling automático en HistoricoDispositivo sincronizado con la frecuencia de lectura del dispositivo ESP32
 - Suite de tests con Vitest: 21 tests en 7 archivos (ver [TESTING_VITEST.md](./docs/TESTING_VITEST.md))
 - Configurado para despliegue en Vercel
 
@@ -142,7 +144,7 @@ Cada componente tiene documentación técnica detallada:
 
 - [x] Modelo de datos (E/R, UML, Relacional)
 - [x] PostgreSQL 16 + TimescaleDB 2.23.1
-- [x] 8 Entidades JPA con validaciones completas
+- [x] 8 entidades JPA con validaciones completas; cada dispositivo ESP32 asociado a un centro educativo
 - [x] Repositorios JPA con queries derivadas
 - [x] ArbolController (GET, POST, PUT, DELETE con @Valid)
 - [x] CentroEducativoController (GET, POST, PUT, DELETE con @Valid)
@@ -158,7 +160,7 @@ Cada componente tiene documentación técnica detallada:
 - [x] Frontend React - CRUD Árboles (Fase 4 - 100% completada)
   - [x] Servicios API (arbolesService, centrosService)
   - [x] ListadoArboles (tabla responsive, filtros, cards móvil)
-  - [x] DetalleArbol (vista completa, eliminar con confirmación, última lectura IoT)
+  - [x] DetalleArbol (vista completa, información general del árbol, eliminar con confirmación)
   - [x] FormularioArbol (crear/editar, validaciones completas)
   - [x] Rutas configuradas y funcionando
   - [x] Refactorización Login/Register con componentes comunes
@@ -171,13 +173,13 @@ Cada componente tiene documentación técnica detallada:
   - [x] Manual de Usuario (Web + móvil)
   - [x] Manuales específicos de Android
 - [x] ESP32 Firmware (lectura sensores + envío al backend)
-- [x] Lecturas IoT en frontend (HistoricoArbol con gráfica Recharts + mapa Leaflet, DetalleArbol con última lectura)
+- [x] Lecturas IoT en frontend (HistoricoDispositivo con gráfica Recharts + mapa Leaflet)
 - [x] Testing frontend con Vitest — 21 tests en 7 archivos, cobertura ~60%
 - [x] CRUD completo para todas las entidades de la BD (Fase 14): DispositivoEsp32Controller, AlertaController, NotificacionController
 
 ## Estado del Proyecto
 
-**Fase actual**: Fases 1–11, 14 completadas | Fases 12, 13 y 15 pendientes (2ª evaluación)
+**Fase actual**: Fases 1–11, 14 completadas + refactor dispositivo-centro | Fases 12, 13 y 15 pendientes (2ª evaluación)
 
 ### Completado (Fase 0 - Configuración Inicial)
 - [x] Configuración de entornos de desarrollo
@@ -270,10 +272,9 @@ Cada componente tiene documentación técnica detallada:
 - [x] **DTOs de autenticación**: LoginRequest, RegisterRequest, AuthResponse
 
 ### Completado (Lecturas IoT + ESP32)
-- [x] **LecturaController**: GET (paginado, última lectura, stride sampling por período), POST `/api/lecturas`
+- [x] **LecturaController**: GET (paginado, última lectura, stride sampling por período), POST `/api/lecturas/dispositivo/{id}`
 - [x] **TimescaleDB hypertable**: tabla `lectura` configurada para series temporales
-- [x] **HistoricoArbol.jsx**: dos gráficas independientes (sensores 0-100% y CO2 en ppm) con stride sampling + tabla paginada + polling automático sincronizado con `frecuencia_lectura_seg` del ESP32
-- [x] **DetalleArbol.jsx**: sección "Última Lectura" con indicadores de umbrales
+- [x] **HistoricoDispositivo.jsx**: dos gráficas independientes (sensores 0-100% y CO2 en ppm) con stride sampling + tabla paginada + polling automático sincronizado con `frecuencia_lectura_seg` del ESP32
 - [x] **ESP32 firmware**: SHT40 (temperatura/humedad ambiente) + sensor capacitivo (humedad suelo) + MH-Z19D (CO2) + LDR x2 (luz1/luz2) + envío HTTP REST
 
 ### Completado (Fase 9 - Testing Frontend)
@@ -289,10 +290,20 @@ Cada componente tiene documentación técnica detallada:
 ### Completado (Fase 14 - CRUD Entidades Pendientes)
 - [x] **Entidades JPA nuevas**: Alerta (con TipoAlerta, EstadoAlerta) y Notificacion — con Javadoc completo
 - [x] **Repositorios JPA**: AlertaRepository y NotificacionRepository con queries derivadas
-- [x] **DispositivoEsp32Controller**: GET, POST, PUT, DELETE `/api/dispositivos` (+ GET /activos)
-- [x] **AlertaController**: GET, POST, PUT, DELETE `/api/alertas` (+ filtros por árbol y estado)
+- [x] **DispositivoEsp32Controller**: GET, POST, PUT, DELETE `/api/dispositivos` (+ GET /activos, GET /centro/{id}, PATCH /{id}/umbrales)
+- [x] **AlertaController**: GET, POST, PUT, DELETE `/api/alertas` (+ filtros por dispositivo y estado)
 - [x] **NotificacionController**: GET, POST, PUT, DELETE `/api/notificaciones` (+ filtros por usuario y no leídas)
 - [x] **Javadoc**: añadido a todos los modelos y controladores sin documentar (UsuarioCentro, Lectura, ArbolController, AuthController, LecturaController, UsuarioCentroController, UsuarioController)
+
+### Completado (Refactor Dispositivo-Centro)
+- [x] **Modelo dispositivo-centro**: cada `DispositivoEsp32` pertenece directamente a un `CentroEducativo` (relación N:1); migración SQL idempotente aplicada en local y producción
+- [x] **Umbrales en dispositivo**: campos `umbralTempMin/Max`, `umbralHumedadAmbienteMin/Max`, `umbralHumedadSueloMin`, `umbralCO2Max` trasladados a `DispositivoEsp32`
+- [x] **Frontend — DetalleCentro**: sección "Dispositivos ESP32" con tabla de dispositivos del centro, acciones Histórico/Editar/Eliminar y modal de confirmación
+- [x] **Frontend — FormularioDispositivo**: formulario de alta/edición con validación de MAC (`XX:XX:XX:XX:XX:XX`), frecuencia y umbrales opcionales
+- [x] **Frontend — HistoricoDispositivo**: gráficas + tabla paginada + polling; accesible desde `DetalleCentro`
+- [x] **Frontend — DetalleArbol**: muestra únicamente información de inventario del árbol (nombre, especie, fecha, ubicación, absorción CO2)
+- [x] **dispositivosService.js**: CRUD completo para `/api/dispositivos`
+- [x] **lecturasService.js**: endpoints actualizados a `/api/lecturas/dispositivo/{id}`
 
 ## Requisitos Académicos
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -73,7 +73,7 @@ psql -U postgres -f create_database.sql
 El archivo [`create_database.sql`](./create_database.sql) contiene:
 - Creación de base de datos
 - Habilitación de extensión TimescaleDB
-- Creación de todas las tablas (8 entidades)
+- Creación de todas las tablas (9 entidades)
 - Configuración de hypertable para series temporales
 - Todos los índices y constraints
 
@@ -152,10 +152,13 @@ El servidor estará disponible en: `http://localhost:8080`
 - `PUT /api/centros/{id}` - Actualizar centro
 - `DELETE /api/centros/{id}` - Eliminar centro
 
-### Árboles (Relación 1:N)
-- `GET /api/centros/{id}/arboles` - Listar árboles de un centro
+### Árboles (Relación 1:N con CentroEducativo)
 - `GET /api/arboles` - Listar todos los árboles
 - `GET /api/arboles/{id}` - Obtener árbol
+- `GET /api/arboles/centro/{centroId}` - Árboles de un centro
+- `GET /api/arboles/especie/{especie}` - Árboles por especie
+- `GET /api/arboles/buscar/{nombre}` - Búsqueda por nombre (parcial, case-insensitive)
+- `GET /api/arboles/ordenados` - Todos los árboles ordenados por nombre
 - `POST /api/arboles` - Crear árbol
 - `PUT /api/arboles/{id}` - Actualizar árbol
 - `DELETE /api/arboles/{id}` - Eliminar árbol
@@ -175,26 +178,28 @@ El servidor estará disponible en: `http://localhost:8080`
 - `DELETE /api/usuario-centro/{id}` - Desasignar coordinador
 
 ### Lecturas IoT
-- `GET /api/lecturas/arbol/{id}` - Listar lecturas de un árbol (paginado)
-- `GET /api/lecturas/arbol/{id}/ultima` - Obtener la última lectura del árbol
-- `GET /api/lecturas/arbol/{id}/grafica?periodo={DIA|SEMANA|MES|SEMESTRE|ANIO}` - Stride sampling: hasta 400 lecturas reales del rango, sin promedios
-- `POST /api/lecturas` - Crear lectura (usado por el firmware ESP32)
+- `POST /api/lecturas` - Recibir lectura desde ESP32 (busca dispositivo por MAC, verifica que tenga centro asignado)
+- `GET /api/lecturas/dispositivo/{id}` - Lecturas de un dispositivo (paginado, DESC)
+- `GET /api/lecturas/dispositivo/{id}/rango?desde=&hasta=` - Lecturas en rango de fechas (paginado)
+- `GET /api/lecturas/dispositivo/{id}/grafica?periodo={DIA|SEMANA|MES|SEMESTRE|ANIO}` - Stride sampling: hasta 400 lecturas reales del rango, sin promedios
 
 ### Dispositivos ESP32
 - `GET /api/dispositivos` - Listar todos los dispositivos
 - `GET /api/dispositivos/{id}` - Obtener dispositivo
 - `GET /api/dispositivos/activos` - Listar dispositivos activos
-- `POST /api/dispositivos` - Registrar dispositivo (valida MAC única)
-- `PUT /api/dispositivos/{id}` - Actualizar dispositivo
-- `DELETE /api/dispositivos/{id}` - Eliminar dispositivo
+- `GET /api/dispositivos/centro/{centroId}` - Listar dispositivos de un centro educativo
+- `POST /api/dispositivos` - Registrar dispositivo (valida MAC única; requiere centroEducativo.id)
+- `PUT /api/dispositivos/{id}` - Actualizar dispositivo (MAC, activo, frecuencia, centro, umbrales)
+- `PATCH /api/dispositivos/{id}/umbrales` - Actualizar solo los umbrales de alerta
+- `DELETE /api/dispositivos/{id}` - Eliminar dispositivo (cascada: lecturas y alertas)
 
 ### Alertas
 - `GET /api/alertas` - Listar todas las alertas
 - `GET /api/alertas/{id}` - Obtener alerta
-- `GET /api/alertas/arbol/{arbolId}` - Alertas de un árbol
+- `GET /api/alertas/dispositivo/{dispositivoId}` - Alertas de un dispositivo
 - `GET /api/alertas/estado/{estado}` - Alertas por estado (ACTIVA, RESUELTA, IGNORADA)
-- `GET /api/alertas/arbol/{arbolId}/estado/{estado}` - Alertas de un árbol por estado
-- `POST /api/alertas` - Crear alerta
+- `GET /api/alertas/dispositivo/{dispositivoId}/estado/{estado}` - Alertas de un dispositivo por estado
+- `POST /api/alertas` - Crear alerta (requiere dispositivo.id)
 - `PUT /api/alertas/{id}` - Actualizar alerta (tipo, mensaje, estado, fechaResolucion)
 - `DELETE /api/alertas/{id}` - Eliminar alerta
 
@@ -268,7 +273,7 @@ Ver sección "Despliegue en Render" más abajo para detalles completos.
 
 ### [AED] Acceso a Datos
 - [x] Modelo de datos documentado
-- [x] Mapeo ORM con JPA completado (8 entidades JPA)
+- [x] Mapeo ORM con JPA completado (9 entidades JPA)
 - [x] Repositorios JPA con queries derivadas
 - [x] Relaciones bidireccionales implementadas
 
@@ -276,10 +281,12 @@ Ver sección "Despliegue en Render" más abajo para detalles completos.
 
 **API REST completada y desplegada en producción**
 
-- [x] 8 Entidades JPA con anotaciones completas, Javadoc y validaciones
+- [x] 9 Entidades JPA con anotaciones completas, Javadoc y validaciones
 - [x] Repositorios JPA con queries derivadas
 - [x] Relaciones bidireccionales (CentroEducativo ↔ Arbol)
 - [x] Relación N:M (Usuario ↔ CentroEducativo via UsuarioCentro)
+- [x] Modelo dispositivo-centro (1:N): un centro puede tener varios dispositivos ESP32
+- [x] Umbrales de alerta en DispositivoEsp32 (movidos desde Arbol)
 - [x] CRUD completo para Árboles, Centros Educativos y Usuarios
 - [x] Autenticación real contra BD (login/register via AuthController)
 - [x] Sistema de roles (ADMIN, COORDINADOR)
@@ -292,7 +299,7 @@ Ver sección "Despliegue en Render" más abajo para detalles completos.
 ## Archivos Importantes del Backend
 
 ### Scripts SQL
-- [`create_database.sql`](./create_database.sql) - Script completo de creación de base de datos (8 tablas)
+- [`create_database.sql`](./create_database.sql) - Script completo de creación de base de datos (9 tablas)
 - [`drop_tables.sql`](./drop_tables.sql) - Script para eliminar todas las tablas (resetear BD)
 
 ### Configuración
@@ -463,7 +470,7 @@ Ver [Manual de Instalación](../docs/MANUAL_DE_INSTALACION.md) para más detalle
 
 **Repositorio**: [github.com/riordi80/vocational-training-final-project](https://github.com/riordi80/vocational-training-final-project)
 
-**Última actualización**: 2026-02-22
+**Última actualización**: 2026-04-11
 
 ### Colaboradores
 

--- a/backend/create_database.sql
+++ b/backend/create_database.sql
@@ -59,6 +59,13 @@ CREATE TABLE dispositivo_esp32 (
     activo BOOLEAN NOT NULL DEFAULT TRUE,
     ultima_conexion TIMESTAMPTZ,
     frecuencia_lectura_seg INTEGER DEFAULT 30,
+    -- Umbrales de alerta (zona del centro)
+    umbral_temp_min DECIMAL(5, 2) DEFAULT 5.00,
+    umbral_temp_max DECIMAL(5, 2) DEFAULT 40.00,
+    umbral_humedad_ambiente_min DECIMAL(5, 2) DEFAULT 30.00,
+    umbral_humedad_ambiente_max DECIMAL(5, 2) DEFAULT 90.00,
+    umbral_humedad_suelo_min DECIMAL(5, 2) DEFAULT 30.00,
+    umbral_co2_max DECIMAL(7, 2) DEFAULT 1000.00,
     CONSTRAINT pk_dispositivo_esp32 PRIMARY KEY (id),
     CONSTRAINT uq_dispositivo_mac_address UNIQUE (mac_address),
     CONSTRAINT fk_dispositivo_centro FOREIGN KEY (centro_id) REFERENCES centro_educativo(id) ON DELETE CASCADE
@@ -77,16 +84,6 @@ CREATE TABLE arbol (
     especie VARCHAR(150) NOT NULL,
     fecha_plantacion DATE NOT NULL,
     ubicacion_especifica VARCHAR(200),
-    -- Umbrales de temperatura
-    umbral_temp_min DECIMAL(5, 2) DEFAULT 5.00,
-    umbral_temp_max DECIMAL(5, 2) DEFAULT 40.00,
-    -- Umbrales de humedad ambiental
-    umbral_humedad_ambiente_min DECIMAL(5, 2) DEFAULT 30.00,
-    umbral_humedad_ambiente_max DECIMAL(5, 2) DEFAULT 90.00,
-    -- Umbrales de humedad del suelo
-    umbral_humedad_suelo_min DECIMAL(5, 2) DEFAULT 30.00,
-    -- Umbrales de CO2 (opcional, solo si tiene sensor)
-    umbral_co2_max DECIMAL(7, 2) DEFAULT 1000.00,
     -- Absorción de CO2 estimada al año (kg CO2/año)
     absorcion_co2_anual DECIMAL(8, 2),
     CONSTRAINT pk_arbol PRIMARY KEY (id),

--- a/backend/create_database.sql
+++ b/backend/create_database.sql
@@ -55,15 +55,17 @@ CREATE INDEX idx_centro_educativo_nombre ON centro_educativo(nombre);
 CREATE TABLE dispositivo_esp32 (
     id BIGSERIAL,
     mac_address VARCHAR(17) NOT NULL,
-    arbol_id BIGINT,
+    centro_id BIGINT NOT NULL,
     activo BOOLEAN NOT NULL DEFAULT TRUE,
     ultima_conexion TIMESTAMPTZ,
     frecuencia_lectura_seg INTEGER DEFAULT 30,
     CONSTRAINT pk_dispositivo_esp32 PRIMARY KEY (id),
-    CONSTRAINT uq_dispositivo_mac_address UNIQUE (mac_address)
+    CONSTRAINT uq_dispositivo_mac_address UNIQUE (mac_address),
+    CONSTRAINT fk_dispositivo_centro FOREIGN KEY (centro_id) REFERENCES centro_educativo(id) ON DELETE CASCADE
 );
 
 CREATE INDEX idx_dispositivo_activo ON dispositivo_esp32(activo);
+CREATE INDEX idx_dispositivo_centro ON dispositivo_esp32(centro_id);
 
 -- ============================================
 -- 4. TABLA: arbol
@@ -75,7 +77,6 @@ CREATE TABLE arbol (
     especie VARCHAR(150) NOT NULL,
     fecha_plantacion DATE NOT NULL,
     ubicacion_especifica VARCHAR(200),
-    dispositivo_id BIGINT,
     -- Umbrales de temperatura
     umbral_temp_min DECIMAL(5, 2) DEFAULT 5.00,
     umbral_temp_max DECIMAL(5, 2) DEFAULT 40.00,
@@ -89,17 +90,11 @@ CREATE TABLE arbol (
     -- Absorción de CO2 estimada al año (kg CO2/año)
     absorcion_co2_anual DECIMAL(8, 2),
     CONSTRAINT pk_arbol PRIMARY KEY (id),
-    CONSTRAINT fk_arbol_centro FOREIGN KEY (centro_id) REFERENCES centro_educativo(id) ON DELETE CASCADE,
-    CONSTRAINT fk_arbol_dispositivo FOREIGN KEY (dispositivo_id) REFERENCES dispositivo_esp32(id) ON DELETE SET NULL,
-    CONSTRAINT uq_arbol_dispositivo UNIQUE (dispositivo_id)
+    CONSTRAINT fk_arbol_centro FOREIGN KEY (centro_id) REFERENCES centro_educativo(id) ON DELETE CASCADE
 );
 
 CREATE INDEX idx_arbol_centro ON arbol(centro_id);
 CREATE INDEX idx_arbol_especie ON arbol(especie);
-
--- Actualizar foreign key en dispositivo_esp32
-ALTER TABLE dispositivo_esp32
-ADD CONSTRAINT fk_dispositivo_arbol FOREIGN KEY (arbol_id) REFERENCES arbol(id) ON DELETE SET NULL;
 
 -- ============================================
 -- 5. TABLA: lectura (HYPERTABLE)
@@ -107,7 +102,6 @@ ADD CONSTRAINT fk_dispositivo_arbol FOREIGN KEY (arbol_id) REFERENCES arbol(id) 
 CREATE TABLE lectura (
     id BIGSERIAL NOT NULL,
     timestamp TIMESTAMPTZ NOT NULL,
-    arbol_id BIGINT NOT NULL,
     dispositivo_id BIGINT NOT NULL,
     -- Sensores obligatorios (configuración básica)
     temperatura DECIMAL(5, 2) NOT NULL,
@@ -118,7 +112,6 @@ CREATE TABLE lectura (
     luz1 DECIMAL(5, 2),                         -- NULL si no tiene sensor LDR 1
     luz2 DECIMAL(5, 2),                         -- NULL si no tiene sensor LDR 2
     CONSTRAINT pk_lectura PRIMARY KEY (id, timestamp),
-    CONSTRAINT fk_lectura_arbol FOREIGN KEY (arbol_id) REFERENCES arbol(id) ON DELETE CASCADE,
     CONSTRAINT fk_lectura_dispositivo FOREIGN KEY (dispositivo_id) REFERENCES dispositivo_esp32(id) ON DELETE CASCADE,
     -- Validaciones de rangos razonables
     CONSTRAINT chk_temperatura CHECK (temperatura BETWEEN -50.00 AND 80.00),
@@ -132,7 +125,6 @@ CREATE TABLE lectura (
 -- Convertir a hypertable (TimescaleDB)
 SELECT create_hypertable('lectura', 'timestamp');
 
-CREATE INDEX idx_lectura_arbol_timestamp ON lectura(arbol_id, timestamp DESC);
 CREATE INDEX idx_lectura_dispositivo_timestamp ON lectura(dispositivo_id, timestamp DESC);
 
 -- ============================================
@@ -140,14 +132,14 @@ CREATE INDEX idx_lectura_dispositivo_timestamp ON lectura(dispositivo_id, timest
 -- ============================================
 CREATE TABLE alerta (
     id BIGSERIAL,
-    arbol_id BIGINT NOT NULL,
+    dispositivo_id BIGINT,
     tipo_alerta VARCHAR(50) NOT NULL,
     timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     mensaje TEXT NOT NULL,
     estado VARCHAR(20) NOT NULL DEFAULT 'ACTIVA',
     fecha_resolucion TIMESTAMPTZ,
     CONSTRAINT pk_alerta PRIMARY KEY (id),
-    CONSTRAINT fk_alerta_arbol FOREIGN KEY (arbol_id) REFERENCES arbol(id) ON DELETE CASCADE,
+    CONSTRAINT fk_alerta_dispositivo FOREIGN KEY (dispositivo_id) REFERENCES dispositivo_esp32(id) ON DELETE CASCADE,
     CONSTRAINT chk_alerta_tipo CHECK (tipo_alerta IN (
         'TEMPERATURA_ALTA',
         'TEMPERATURA_BAJA',
@@ -160,7 +152,7 @@ CREATE TABLE alerta (
     CONSTRAINT chk_alerta_estado CHECK (estado IN ('ACTIVA', 'RESUELTA', 'IGNORADA'))
 );
 
-CREATE INDEX idx_alerta_arbol ON alerta(arbol_id);
+CREATE INDEX idx_alerta_dispositivo ON alerta(dispositivo_id);
 CREATE INDEX idx_alerta_estado ON alerta(estado);
 CREATE INDEX idx_alerta_timestamp ON alerta(timestamp DESC);
 

--- a/backend/migration_dispositivo_centro.sql
+++ b/backend/migration_dispositivo_centro.sql
@@ -78,4 +78,21 @@ DROP INDEX IF EXISTS idx_arbol_dispositivo_esp32;
 ALTER TABLE arbol
     DROP COLUMN IF EXISTS dispositivo_id;
 
+-- 10. Mover umbrales de alerta de arbol → dispositivo_esp32
+ALTER TABLE dispositivo_esp32
+    ADD COLUMN IF NOT EXISTS umbral_temp_min             DECIMAL(5,2) DEFAULT 5.00,
+    ADD COLUMN IF NOT EXISTS umbral_temp_max             DECIMAL(5,2) DEFAULT 40.00,
+    ADD COLUMN IF NOT EXISTS umbral_humedad_ambiente_min DECIMAL(5,2) DEFAULT 30.00,
+    ADD COLUMN IF NOT EXISTS umbral_humedad_ambiente_max DECIMAL(5,2) DEFAULT 90.00,
+    ADD COLUMN IF NOT EXISTS umbral_humedad_suelo_min    DECIMAL(5,2) DEFAULT 30.00,
+    ADD COLUMN IF NOT EXISTS umbral_co2_max              DECIMAL(7,2) DEFAULT 1000.00;
+
+ALTER TABLE arbol
+    DROP COLUMN IF EXISTS umbral_temp_min,
+    DROP COLUMN IF EXISTS umbral_temp_max,
+    DROP COLUMN IF EXISTS umbral_humedad_ambiente_min,
+    DROP COLUMN IF EXISTS umbral_humedad_ambiente_max,
+    DROP COLUMN IF EXISTS umbral_humedad_suelo_min,
+    DROP COLUMN IF EXISTS umbral_co2_max;
+
 COMMIT;

--- a/backend/migration_dispositivo_centro.sql
+++ b/backend/migration_dispositivo_centro.sql
@@ -1,21 +1,20 @@
 -- ============================================
 -- MIGRACIÓN: modelo dispositivo-árbol → dispositivo-centro
+-- + traslado de umbrales de arbol → dispositivo_esp32
 -- Ejecutar en local y en Render (producción)
 -- ============================================
 
 BEGIN;
 
--- 1. Añadir centro_id en dispositivo_esp32 (nullable primero)
+-- ── 1. dispositivo_esp32: añadir centro_id ──────────────────────────────────
 ALTER TABLE dispositivo_esp32
-    ADD COLUMN centro_id BIGINT;
+    ADD COLUMN IF NOT EXISTS centro_id BIGINT;
 
--- 2. Poblar centro_id a partir del árbol vinculado
 UPDATE dispositivo_esp32 d
 SET centro_id = a.centro_id
 FROM arbol a
 WHERE a.dispositivo_id = d.id;
 
--- 3. Hacer centro_id NOT NULL y añadir FK
 ALTER TABLE dispositivo_esp32
     ALTER COLUMN centro_id SET NOT NULL;
 
@@ -23,70 +22,42 @@ ALTER TABLE dispositivo_esp32
     ADD CONSTRAINT fk_dispositivo_centro
         FOREIGN KEY (centro_id) REFERENCES centro_educativo(id) ON DELETE CASCADE;
 
-CREATE INDEX idx_dispositivo_centro ON dispositivo_esp32(centro_id);
+CREATE INDEX IF NOT EXISTS idx_dispositivo_centro ON dispositivo_esp32(centro_id);
 
--- 4. Eliminar arbol_id de dispositivo_esp32
-ALTER TABLE dispositivo_esp32
-    DROP CONSTRAINT IF EXISTS fk_dispositivo_arbol;
-
-ALTER TABLE dispositivo_esp32
-    DROP COLUMN IF EXISTS arbol_id;
-
--- 5. Añadir dispositivo_id en alerta (nullable — para conservar alertas históricas)
-ALTER TABLE alerta
-    ADD COLUMN dispositivo_id BIGINT;
-
--- 6. Poblar dispositivo_id en alerta a partir del árbol vinculado
+-- ── 2. alerta: dispositivo_id ya existe — poblar nulls y soltar arbol_id ────
 UPDATE alerta al
 SET dispositivo_id = a.dispositivo_id
 FROM arbol a
-WHERE a.id = al.arbol_id;
+WHERE a.id = al.arbol_id
+  AND al.dispositivo_id IS NULL;
 
-ALTER TABLE alerta
-    ADD CONSTRAINT fk_alerta_dispositivo
-        FOREIGN KEY (dispositivo_id) REFERENCES dispositivo_esp32(id) ON DELETE CASCADE;
-
-CREATE INDEX idx_alerta_dispositivo ON alerta(dispositivo_id);
-
--- 7. Eliminar arbol_id de alerta
 DROP INDEX IF EXISTS idx_alerta_arbol;
 
 ALTER TABLE alerta
-    DROP CONSTRAINT IF EXISTS fk_alerta_arbol;
+    DROP CONSTRAINT IF EXISTS fk4j6cyhhtkkxnk7wi2hxdu61op;   -- FK alerta.arbol_id → arbol
 
 ALTER TABLE alerta
     DROP COLUMN IF EXISTS arbol_id;
 
--- 8. Eliminar arbol_id de lectura (hypertable TimescaleDB)
+-- ── 3. lectura: dispositivo_id ya existe — solo soltar arbol_id ─────────────
 DROP INDEX IF EXISTS idx_lectura_arbol_timestamp;
 
 ALTER TABLE lectura
-    DROP CONSTRAINT IF EXISTS fk_lectura_arbol;
+    DROP CONSTRAINT IF EXISTS fkpb4l8cgk437j6cpqnxhb46kpg;   -- FK lectura.arbol_id → arbol
 
 ALTER TABLE lectura
     DROP COLUMN IF EXISTS arbol_id;
 
--- 9. Eliminar dispositivo_id y FK de arbol
+-- ── 4. arbol: soltar dispositivo_id ─────────────────────────────────────────
 ALTER TABLE arbol
-    DROP CONSTRAINT IF EXISTS uq_arbol_dispositivo;
-
-ALTER TABLE arbol
-    DROP CONSTRAINT IF EXISTS fk_arbol_dispositivo;
+    DROP CONSTRAINT IF EXISTS fk_dispositivo_esp32;
 
 DROP INDEX IF EXISTS idx_arbol_dispositivo_esp32;
 
 ALTER TABLE arbol
     DROP COLUMN IF EXISTS dispositivo_id;
 
--- 10. Mover umbrales de alerta de arbol → dispositivo_esp32
-ALTER TABLE dispositivo_esp32
-    ADD COLUMN IF NOT EXISTS umbral_temp_min             DECIMAL(5,2) DEFAULT 5.00,
-    ADD COLUMN IF NOT EXISTS umbral_temp_max             DECIMAL(5,2) DEFAULT 40.00,
-    ADD COLUMN IF NOT EXISTS umbral_humedad_ambiente_min DECIMAL(5,2) DEFAULT 30.00,
-    ADD COLUMN IF NOT EXISTS umbral_humedad_ambiente_max DECIMAL(5,2) DEFAULT 90.00,
-    ADD COLUMN IF NOT EXISTS umbral_humedad_suelo_min    DECIMAL(5,2) DEFAULT 30.00,
-    ADD COLUMN IF NOT EXISTS umbral_co2_max              DECIMAL(7,2) DEFAULT 1000.00;
-
+-- ── 5. arbol: soltar columnas de umbrales (pasan al dispositivo) ─────────────
 ALTER TABLE arbol
     DROP COLUMN IF EXISTS umbral_temp_min,
     DROP COLUMN IF EXISTS umbral_temp_max,
@@ -94,5 +65,14 @@ ALTER TABLE arbol
     DROP COLUMN IF EXISTS umbral_humedad_ambiente_max,
     DROP COLUMN IF EXISTS umbral_humedad_suelo_min,
     DROP COLUMN IF EXISTS umbral_co2_max;
+
+-- ── 6. dispositivo_esp32: añadir columnas de umbrales ───────────────────────
+ALTER TABLE dispositivo_esp32
+    ADD COLUMN IF NOT EXISTS umbral_temp_min             DECIMAL(5,2) DEFAULT 5.00,
+    ADD COLUMN IF NOT EXISTS umbral_temp_max             DECIMAL(5,2) DEFAULT 40.00,
+    ADD COLUMN IF NOT EXISTS umbral_humedad_ambiente_min DECIMAL(5,2) DEFAULT 30.00,
+    ADD COLUMN IF NOT EXISTS umbral_humedad_ambiente_max DECIMAL(5,2) DEFAULT 90.00,
+    ADD COLUMN IF NOT EXISTS umbral_humedad_suelo_min    DECIMAL(5,2) DEFAULT 30.00,
+    ADD COLUMN IF NOT EXISTS umbral_co2_max              DECIMAL(7,2) DEFAULT 1000.00;
 
 COMMIT;

--- a/backend/migration_dispositivo_centro.sql
+++ b/backend/migration_dispositivo_centro.sql
@@ -1,0 +1,81 @@
+-- ============================================
+-- MIGRACIÓN: modelo dispositivo-árbol → dispositivo-centro
+-- Ejecutar en local y en Render (producción)
+-- ============================================
+
+BEGIN;
+
+-- 1. Añadir centro_id en dispositivo_esp32 (nullable primero)
+ALTER TABLE dispositivo_esp32
+    ADD COLUMN centro_id BIGINT;
+
+-- 2. Poblar centro_id a partir del árbol vinculado
+UPDATE dispositivo_esp32 d
+SET centro_id = a.centro_id
+FROM arbol a
+WHERE a.dispositivo_id = d.id;
+
+-- 3. Hacer centro_id NOT NULL y añadir FK
+ALTER TABLE dispositivo_esp32
+    ALTER COLUMN centro_id SET NOT NULL;
+
+ALTER TABLE dispositivo_esp32
+    ADD CONSTRAINT fk_dispositivo_centro
+        FOREIGN KEY (centro_id) REFERENCES centro_educativo(id) ON DELETE CASCADE;
+
+CREATE INDEX idx_dispositivo_centro ON dispositivo_esp32(centro_id);
+
+-- 4. Eliminar arbol_id de dispositivo_esp32
+ALTER TABLE dispositivo_esp32
+    DROP CONSTRAINT IF EXISTS fk_dispositivo_arbol;
+
+ALTER TABLE dispositivo_esp32
+    DROP COLUMN IF EXISTS arbol_id;
+
+-- 5. Añadir dispositivo_id en alerta (nullable — para conservar alertas históricas)
+ALTER TABLE alerta
+    ADD COLUMN dispositivo_id BIGINT;
+
+-- 6. Poblar dispositivo_id en alerta a partir del árbol vinculado
+UPDATE alerta al
+SET dispositivo_id = a.dispositivo_id
+FROM arbol a
+WHERE a.id = al.arbol_id;
+
+ALTER TABLE alerta
+    ADD CONSTRAINT fk_alerta_dispositivo
+        FOREIGN KEY (dispositivo_id) REFERENCES dispositivo_esp32(id) ON DELETE CASCADE;
+
+CREATE INDEX idx_alerta_dispositivo ON alerta(dispositivo_id);
+
+-- 7. Eliminar arbol_id de alerta
+DROP INDEX IF EXISTS idx_alerta_arbol;
+
+ALTER TABLE alerta
+    DROP CONSTRAINT IF EXISTS fk_alerta_arbol;
+
+ALTER TABLE alerta
+    DROP COLUMN IF EXISTS arbol_id;
+
+-- 8. Eliminar arbol_id de lectura (hypertable TimescaleDB)
+DROP INDEX IF EXISTS idx_lectura_arbol_timestamp;
+
+ALTER TABLE lectura
+    DROP CONSTRAINT IF EXISTS fk_lectura_arbol;
+
+ALTER TABLE lectura
+    DROP COLUMN IF EXISTS arbol_id;
+
+-- 9. Eliminar dispositivo_id y FK de arbol
+ALTER TABLE arbol
+    DROP CONSTRAINT IF EXISTS uq_arbol_dispositivo;
+
+ALTER TABLE arbol
+    DROP CONSTRAINT IF EXISTS fk_arbol_dispositivo;
+
+DROP INDEX IF EXISTS idx_arbol_dispositivo_esp32;
+
+ALTER TABLE arbol
+    DROP COLUMN IF EXISTS dispositivo_id;
+
+COMMIT;

--- a/backend/src/main/java/com/example/gardenmonitor/controller/AlertaController.java
+++ b/backend/src/main/java/com/example/gardenmonitor/controller/AlertaController.java
@@ -1,10 +1,10 @@
 package com.example.gardenmonitor.controller;
 
 import com.example.gardenmonitor.model.Alerta;
-import com.example.gardenmonitor.model.Arbol;
+import com.example.gardenmonitor.model.DispositivoEsp32;
 import com.example.gardenmonitor.model.EstadoAlerta;
 import com.example.gardenmonitor.repository.AlertaRepository;
-import com.example.gardenmonitor.repository.ArbolRepository;
+import com.example.gardenmonitor.repository.DispositivoEsp32Repository;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -17,9 +17,9 @@ import java.util.List;
  * Controlador REST para gestionar alertas del sistema de monitorización.
  * <p>
  * Proporciona endpoints para operaciones CRUD de alertas, así como
- * consultas filtradas por árbol y por estado.
+ * consultas filtradas por dispositivo y por estado.
  * Las alertas se generan cuando los valores de sensores superan los umbrales
- * configurados en cada árbol.
+ * configurados en cada dispositivo.
  * </p>
  *
  * @author Richard Ortiz y Enrique Pérez
@@ -33,7 +33,7 @@ public class AlertaController {
     private AlertaRepository alertaRepository;
 
     @Autowired
-    private ArbolRepository arbolRepository;
+    private DispositivoEsp32Repository dispositivoRepository;
 
     /**
      * Obtiene todas las alertas del sistema.
@@ -60,18 +60,18 @@ public class AlertaController {
     }
 
     /**
-     * Obtiene todas las alertas de un árbol específico.
+     * Obtiene todas las alertas de un dispositivo específico.
      *
-     * @param arbolId identificador del árbol
-     * @return lista de alertas del árbol
-     * @throws ResponseStatusException si no se encuentra el árbol (404)
+     * @param dispositivoId identificador del dispositivo
+     * @return lista de alertas del dispositivo
+     * @throws ResponseStatusException si no se encuentra el dispositivo (404)
      */
-    @GetMapping("/arbol/{arbolId}")
-    public List<Alerta> obtenerAlertasPorArbol(@PathVariable("arbolId") Long arbolId) {
-        if (!arbolRepository.existsById(arbolId)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Árbol no encontrado");
+    @GetMapping("/dispositivo/{dispositivoId}")
+    public List<Alerta> obtenerAlertasPorDispositivo(@PathVariable("dispositivoId") Long dispositivoId) {
+        if (!dispositivoRepository.existsById(dispositivoId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Dispositivo no encontrado");
         }
-        return alertaRepository.findByArbol_Id(arbolId);
+        return alertaRepository.findByDispositivo_Id(dispositivoId);
     }
 
     /**
@@ -86,43 +86,43 @@ public class AlertaController {
     }
 
     /**
-     * Obtiene las alertas de un árbol filtradas por estado.
+     * Obtiene las alertas de un dispositivo filtradas por estado.
      *
-     * @param arbolId identificador del árbol
-     * @param estado  estado de las alertas a filtrar (ACTIVA, RESUELTA, IGNORADA)
-     * @return lista de alertas del árbol con el estado indicado
-     * @throws ResponseStatusException si no se encuentra el árbol (404)
+     * @param dispositivoId identificador del dispositivo
+     * @param estado        estado de las alertas a filtrar (ACTIVA, RESUELTA, IGNORADA)
+     * @return lista de alertas del dispositivo con el estado indicado
+     * @throws ResponseStatusException si no se encuentra el dispositivo (404)
      */
-    @GetMapping("/arbol/{arbolId}/estado/{estado}")
-    public List<Alerta> obtenerAlertasPorArbolYEstado(
-            @PathVariable("arbolId") Long arbolId,
+    @GetMapping("/dispositivo/{dispositivoId}/estado/{estado}")
+    public List<Alerta> obtenerAlertasPorDispositivoYEstado(
+            @PathVariable("dispositivoId") Long dispositivoId,
             @PathVariable("estado") EstadoAlerta estado) {
-        if (!arbolRepository.existsById(arbolId)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Árbol no encontrado");
+        if (!dispositivoRepository.existsById(dispositivoId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Dispositivo no encontrado");
         }
-        return alertaRepository.findByArbol_IdAndEstado(arbolId, estado);
+        return alertaRepository.findByDispositivo_IdAndEstado(dispositivoId, estado);
     }
 
     /**
-     * Crea una nueva alerta para un árbol.
+     * Crea una nueva alerta para un dispositivo.
      * <p>
-     * Verifica que el árbol indicado exista antes de crear la alerta.
+     * Verifica que el dispositivo indicado exista antes de crear la alerta.
      * El estado inicial es ACTIVA y el timestamp se establece automáticamente.
      * </p>
      *
      * @param alerta datos de la alerta a crear (validado con @Valid)
      * @return la alerta creada
-     * @throws ResponseStatusException si no se encuentra el árbol (404)
+     * @throws ResponseStatusException si no se encuentra el dispositivo (404)
      */
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public Alerta crearAlerta(@Valid @RequestBody Alerta alerta) {
-        Long arbolId = alerta.getArbol() != null ? alerta.getArbol().getId() : null;
-        if (arbolId == null || !arbolRepository.existsById(arbolId)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Árbol no encontrado");
+        Long dispositivoId = alerta.getDispositivo() != null ? alerta.getDispositivo().getId() : null;
+        if (dispositivoId == null || !dispositivoRepository.existsById(dispositivoId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Dispositivo no encontrado");
         }
-        Arbol arbol = arbolRepository.findById(arbolId).get();
-        alerta.setArbol(arbol);
+        DispositivoEsp32 dispositivo = dispositivoRepository.findById(dispositivoId).get();
+        alerta.setDispositivo(dispositivo);
         return alertaRepository.save(alerta);
     }
 
@@ -130,7 +130,7 @@ public class AlertaController {
      * Actualiza una alerta existente.
      * <p>
      * Permite modificar el tipo, mensaje, estado y fecha de resolución.
-     * El árbol asociado no se puede cambiar una vez creada la alerta.
+     * El dispositivo asociado no se puede cambiar una vez creada la alerta.
      * </p>
      *
      * @param id      identificador de la alerta a actualizar

--- a/backend/src/main/java/com/example/gardenmonitor/controller/ArbolController.java
+++ b/backend/src/main/java/com/example/gardenmonitor/controller/ArbolController.java
@@ -150,12 +150,6 @@ public class ArbolController {
         arbol.setEspecie(detallesArbol.getEspecie());
         arbol.setFechaPlantacion(detallesArbol.getFechaPlantacion());
         arbol.setUbicacionEspecifica(detallesArbol.getUbicacionEspecifica());
-        arbol.setUmbralTempMin(detallesArbol.getUmbralTempMin());
-        arbol.setUmbralTempMax(detallesArbol.getUmbralTempMax());
-        arbol.setUmbralHumedadAmbienteMin(detallesArbol.getUmbralHumedadAmbienteMin());
-        arbol.setUmbralHumedadAmbienteMax(detallesArbol.getUmbralHumedadAmbienteMax());
-        arbol.setUmbralHumedadSueloMin(detallesArbol.getUmbralHumedadSueloMin());
-        arbol.setUmbralCO2Max(detallesArbol.getUmbralCO2Max());
         arbol.setAbsorcionCo2Anual(detallesArbol.getAbsorcionCo2Anual());
 
         return arbolRepository.save(arbol);
@@ -180,43 +174,4 @@ public class ArbolController {
         return arbol;
     }
 
-    /**
-     * Actualiza parcialmente los umbrales de alerta de un árbol.
-     * <p>
-     * Solo actualiza los umbrales que estén presentes (no nulos) en el cuerpo de la petición.
-     * </p>
-     *
-     * @param id       identificador del árbol
-     * @param umbrales objeto con los umbrales a actualizar (los campos null se ignoran)
-     * @return el árbol con los umbrales actualizados
-     * @throws ResponseStatusException si no se encuentra el árbol (404)
-     */
-    @PatchMapping("/{id}/umbrales")
-    public Arbol actualizarUmbrales(@PathVariable("id") Long id,
-                                     @RequestBody Arbol umbrales) {
-        Arbol arbol = arbolRepository.findById(id)
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, "Árbol no encontrado"));
-
-        if (umbrales.getUmbralTempMin() != null) {
-            arbol.setUmbralTempMin(umbrales.getUmbralTempMin());
-        }
-        if (umbrales.getUmbralTempMax() != null) {
-            arbol.setUmbralTempMax(umbrales.getUmbralTempMax());
-        }
-        if (umbrales.getUmbralHumedadAmbienteMin() != null) {
-            arbol.setUmbralHumedadAmbienteMin(umbrales.getUmbralHumedadAmbienteMin());
-        }
-        if (umbrales.getUmbralHumedadAmbienteMax() != null) {
-            arbol.setUmbralHumedadAmbienteMax(umbrales.getUmbralHumedadAmbienteMax());
-        }
-        if (umbrales.getUmbralHumedadSueloMin() != null) {
-            arbol.setUmbralHumedadSueloMin(umbrales.getUmbralHumedadSueloMin());
-        }
-        if (umbrales.getUmbralCO2Max() != null) {
-            arbol.setUmbralCO2Max(umbrales.getUmbralCO2Max());
-        }
-
-        return arbolRepository.save(arbol);
-    }
 }

--- a/backend/src/main/java/com/example/gardenmonitor/controller/ArbolController.java
+++ b/backend/src/main/java/com/example/gardenmonitor/controller/ArbolController.java
@@ -2,7 +2,6 @@ package com.example.gardenmonitor.controller;
 
 import com.example.gardenmonitor.model.Arbol;
 import com.example.gardenmonitor.model.CentroEducativo;
-import com.example.gardenmonitor.model.DispositivoEsp32;
 import com.example.gardenmonitor.repository.ArbolRepository;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -80,22 +79,6 @@ public class ArbolController {
     }
 
     /**
-     * Obtiene el árbol asociado a un dispositivo ESP32 específico.
-     *
-     * @param dispositivoId identificador del dispositivo ESP32
-     * @return el árbol asociado al dispositivo
-     * @throws ResponseStatusException si no se encuentra ningún árbol para ese dispositivo (404)
-     */
-    @GetMapping("/dispositivo/{dispositivoId}")
-    public Arbol obtenerArbolPorDispositivo(@PathVariable("dispositivoId") Long dispositivoId) {
-        DispositivoEsp32 dispositivo = new DispositivoEsp32();
-        dispositivo.setId(dispositivoId);
-        return arbolRepository.findByDispositivoEsp32(dispositivo)
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, "Árbol no encontrado para este dispositivo"));
-    }
-
-    /**
      * Busca árboles cuyo nombre contenga el texto indicado (insensible a mayúsculas).
      *
      * @param nombre texto a buscar en el nombre del árbol
@@ -167,7 +150,6 @@ public class ArbolController {
         arbol.setEspecie(detallesArbol.getEspecie());
         arbol.setFechaPlantacion(detallesArbol.getFechaPlantacion());
         arbol.setUbicacionEspecifica(detallesArbol.getUbicacionEspecifica());
-        arbol.setDispositivoEsp32(detallesArbol.getDispositivoEsp32());
         arbol.setUmbralTempMin(detallesArbol.getUmbralTempMin());
         arbol.setUmbralTempMax(detallesArbol.getUmbralTempMax());
         arbol.setUmbralHumedadAmbienteMin(detallesArbol.getUmbralHumedadAmbienteMin());
@@ -196,28 +178,6 @@ public class ArbolController {
                         HttpStatus.NOT_FOUND, "Árbol no encontrado"));
         arbolRepository.deleteById(id);
         return arbol;
-    }
-
-    /**
-     * Asigna un dispositivo ESP32 a un árbol.
-     * <p>
-     * Este endpoint gestiona la relación 1:1 entre árbol y dispositivo.
-     * Para desasignar el dispositivo, enviar {@code {"id": null}}.
-     * </p>
-     *
-     * @param id          identificador del árbol
-     * @param dispositivo dispositivo a asignar (puede contener solo el id)
-     * @return el árbol con el dispositivo actualizado
-     * @throws ResponseStatusException si no se encuentra el árbol (404)
-     */
-    @PatchMapping("/{id}/dispositivo")
-    public Arbol asignarDispositivo(@PathVariable("id") Long id,
-                                     @RequestBody DispositivoEsp32 dispositivo) {
-        Arbol arbol = arbolRepository.findById(id)
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, "Árbol no encontrado"));
-        arbol.setDispositivoEsp32(dispositivo);
-        return arbolRepository.save(arbol);
     }
 
     /**

--- a/backend/src/main/java/com/example/gardenmonitor/controller/DispositivoEsp32Controller.java
+++ b/backend/src/main/java/com/example/gardenmonitor/controller/DispositivoEsp32Controller.java
@@ -131,6 +131,52 @@ public class DispositivoEsp32Controller {
         dispositivo.setActivo(detalles.isActivo());
         dispositivo.setUltimaConexion(detalles.getUltimaConexion());
         dispositivo.setFrecuenciaLecturaSeg(detalles.getFrecuenciaLecturaSeg());
+        dispositivo.setUmbralTempMin(detalles.getUmbralTempMin());
+        dispositivo.setUmbralTempMax(detalles.getUmbralTempMax());
+        dispositivo.setUmbralHumedadAmbienteMin(detalles.getUmbralHumedadAmbienteMin());
+        dispositivo.setUmbralHumedadAmbienteMax(detalles.getUmbralHumedadAmbienteMax());
+        dispositivo.setUmbralHumedadSueloMin(detalles.getUmbralHumedadSueloMin());
+        dispositivo.setUmbralCO2Max(detalles.getUmbralCO2Max());
+
+        return dispositivoRepository.save(dispositivo);
+    }
+
+    /**
+     * Actualiza parcialmente los umbrales de alerta de un dispositivo.
+     * <p>
+     * Solo actualiza los umbrales que estén presentes (no nulos) en el cuerpo de la petición.
+     * </p>
+     *
+     * @param id       identificador del dispositivo
+     * @param umbrales objeto con los umbrales a actualizar (los campos null se ignoran)
+     * @return el dispositivo con los umbrales actualizados
+     * @throws ResponseStatusException si no se encuentra el dispositivo (404)
+     */
+    @PatchMapping("/{id}/umbrales")
+    public DispositivoEsp32 actualizarUmbrales(@PathVariable("id") Long id,
+                                                @RequestBody DispositivoEsp32 umbrales) {
+        DispositivoEsp32 dispositivo = dispositivoRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Dispositivo no encontrado"));
+
+        if (umbrales.getUmbralTempMin() != null) {
+            dispositivo.setUmbralTempMin(umbrales.getUmbralTempMin());
+        }
+        if (umbrales.getUmbralTempMax() != null) {
+            dispositivo.setUmbralTempMax(umbrales.getUmbralTempMax());
+        }
+        if (umbrales.getUmbralHumedadAmbienteMin() != null) {
+            dispositivo.setUmbralHumedadAmbienteMin(umbrales.getUmbralHumedadAmbienteMin());
+        }
+        if (umbrales.getUmbralHumedadAmbienteMax() != null) {
+            dispositivo.setUmbralHumedadAmbienteMax(umbrales.getUmbralHumedadAmbienteMax());
+        }
+        if (umbrales.getUmbralHumedadSueloMin() != null) {
+            dispositivo.setUmbralHumedadSueloMin(umbrales.getUmbralHumedadSueloMin());
+        }
+        if (umbrales.getUmbralCO2Max() != null) {
+            dispositivo.setUmbralCO2Max(umbrales.getUmbralCO2Max());
+        }
 
         return dispositivoRepository.save(dispositivo);
     }

--- a/backend/src/main/java/com/example/gardenmonitor/controller/DispositivoEsp32Controller.java
+++ b/backend/src/main/java/com/example/gardenmonitor/controller/DispositivoEsp32Controller.java
@@ -2,6 +2,7 @@ package com.example.gardenmonitor.controller;
 
 import com.example.gardenmonitor.model.DispositivoEsp32;
 import com.example.gardenmonitor.repository.DispositivoEsp32Repository;
+import com.example.gardenmonitor.repository.CentroEducativoRepository;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -26,6 +27,9 @@ public class DispositivoEsp32Controller {
 
     @Autowired
     private DispositivoEsp32Repository dispositivoRepository;
+
+    @Autowired
+    private CentroEducativoRepository centroRepository;
 
     /**
      * Obtiene todos los dispositivos ESP32 registrados.
@@ -62,6 +66,21 @@ public class DispositivoEsp32Controller {
     }
 
     /**
+     * Obtiene todos los dispositivos ESP32 de un centro educativo.
+     *
+     * @param centroId identificador del centro educativo
+     * @return lista de dispositivos del centro
+     * @throws ResponseStatusException si no se encuentra el centro (404)
+     */
+    @GetMapping("/centro/{centroId}")
+    public List<DispositivoEsp32> obtenerDispositivosPorCentro(@PathVariable("centroId") Long centroId) {
+        if (!centroRepository.existsById(centroId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Centro educativo no encontrado");
+        }
+        return dispositivoRepository.findByCentroEducativo_Id(centroId);
+    }
+
+    /**
      * Registra un nuevo dispositivo ESP32.
      * <p>
      * Valida que no exista otro dispositivo con la misma dirección MAC.
@@ -85,7 +104,7 @@ public class DispositivoEsp32Controller {
      * Actualiza un dispositivo ESP32 existente.
      * <p>
      * Valida que la nueva dirección MAC no esté ya registrada en otro dispositivo.
-     * La relación con el árbol se gestiona desde ArbolController (PATCH /api/arboles/{id}/dispositivo).
+     * La relación con el centro se gestiona mediante el campo centroEducativo del cuerpo de la petición.
      * </p>
      *
      * @param id      identificador del dispositivo a actualizar
@@ -119,9 +138,8 @@ public class DispositivoEsp32Controller {
     /**
      * Elimina un dispositivo ESP32 por su ID.
      * <p>
-     * IMPORTANTE: Al eliminar un dispositivo, la FK en arbol.dispositivo_id
-     * se establece a NULL (ON DELETE SET NULL) y se eliminan sus lecturas asociadas
-     * (ON DELETE CASCADE en la tabla lectura).
+     * IMPORTANTE: Al eliminar un dispositivo, se eliminan en cascada todas sus
+     * lecturas y alertas asociadas (ON DELETE CASCADE).
      * </p>
      *
      * @param id identificador del dispositivo a eliminar

--- a/backend/src/main/java/com/example/gardenmonitor/controller/LecturaController.java
+++ b/backend/src/main/java/com/example/gardenmonitor/controller/LecturaController.java
@@ -1,10 +1,8 @@
 package com.example.gardenmonitor.controller;
 
 import com.example.gardenmonitor.dto.LecturaRequest;
-import com.example.gardenmonitor.model.Arbol;
 import com.example.gardenmonitor.model.DispositivoEsp32;
 import com.example.gardenmonitor.model.Lectura;
-import com.example.gardenmonitor.repository.ArbolRepository;
 import com.example.gardenmonitor.repository.DispositivoEsp32Repository;
 import com.example.gardenmonitor.repository.LecturaRepository;
 import com.example.gardenmonitor.dto.LecturaMuestraProjection;
@@ -24,7 +22,7 @@ import java.util.List;
  * Controlador REST para gestionar lecturas de sensores IoT.
  * <p>
  * Proporciona endpoints para recibir lecturas enviadas por dispositivos ESP32
- * y para consultar el histórico de lecturas de un árbol. Soporta paginación
+ * y para consultar el histórico de lecturas de un dispositivo. Soporta paginación
  * server-side y stride sampling para optimizar la carga de datos en gráficas.
  * </p>
  *
@@ -41,9 +39,6 @@ public class LecturaController {
     @Autowired
     private DispositivoEsp32Repository dispositivoEsp32Repository;
 
-    @Autowired
-    private ArbolRepository arbolRepository;
-
     /**
      * Recibe una lectura enviada por un dispositivo ESP32.
      * <p>
@@ -51,7 +46,7 @@ public class LecturaController {
      * </p>
      * <ol>
      *   <li>Busca el dispositivo por dirección MAC</li>
-     *   <li>Verifica que el dispositivo tiene un árbol asignado</li>
+     *   <li>Verifica que el dispositivo tiene un centro asignado</li>
      *   <li>Crea la lectura con timestamp actual</li>
      *   <li>Actualiza la fecha de última conexión del dispositivo</li>
      * </ol>
@@ -59,7 +54,7 @@ public class LecturaController {
      * @param request datos de la lectura enviada por el ESP32 (validado con @Valid)
      * @return la lectura registrada
      * @throws ResponseStatusException si el dispositivo no está registrado (404)
-     *                                 o no tiene árbol asignado (422)
+     *                                 o no tiene centro asignado (422)
      */
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -71,18 +66,16 @@ public class LecturaController {
                         HttpStatus.NOT_FOUND,
                         "Dispositivo no registrado: " + request.getMacAddress()));
 
-        // 2. Verificar que tiene árbol asignado
-        Arbol arbol = dispositivo.getArbol();
-        if (arbol == null) {
+        // 2. Verificar que tiene centro asignado
+        if (dispositivo.getCentroEducativo() == null) {
             throw new ResponseStatusException(
                     HttpStatus.UNPROCESSABLE_ENTITY,
-                    "Dispositivo sin árbol asignado: " + request.getMacAddress());
+                    "Dispositivo sin centro asignado: " + request.getMacAddress());
         }
 
         // 3. Crear lectura
         Lectura lectura = new Lectura();
         lectura.setTimestamp(LocalDateTime.now());
-        lectura.setArbol(arbol);
         lectura.setDispositivo(dispositivo);
         lectura.setTemperatura(request.getTemperatura());
         lectura.setHumedadAmbiente(request.getHumedadAmbiente());
@@ -99,49 +92,49 @@ public class LecturaController {
     }
 
     /**
-     * Obtiene las lecturas de un árbol paginadas, ordenadas por timestamp descendente.
+     * Obtiene las lecturas de un dispositivo paginadas, ordenadas por timestamp descendente.
      *
-     * @param arbolId identificador del árbol
-     * @param page    número de página (0-indexed, por defecto 0)
-     * @param size    tamaño de página (por defecto 20)
-     * @return página de lecturas del árbol
-     * @throws ResponseStatusException si no se encuentra el árbol (404)
+     * @param dispositivoId identificador del dispositivo
+     * @param page          número de página (0-indexed, por defecto 0)
+     * @param size          tamaño de página (por defecto 20)
+     * @return página de lecturas del dispositivo
+     * @throws ResponseStatusException si no se encuentra el dispositivo (404)
      */
-    @GetMapping("/arbol/{arbolId}")
-    public Page<Lectura> obtenerLecturasPorArbol(
-            @PathVariable("arbolId") Long arbolId,
+    @GetMapping("/dispositivo/{dispositivoId}")
+    public Page<Lectura> obtenerLecturasPorDispositivo(
+            @PathVariable("dispositivoId") Long dispositivoId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
-        Arbol arbol = arbolRepository.findById(arbolId)
+        DispositivoEsp32 dispositivo = dispositivoEsp32Repository.findById(dispositivoId)
                 .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, "Árbol no encontrado"));
-        return lecturaRepository.findByArbolOrderByTimestampDesc(
-                arbol, PageRequest.of(page, size));
+                        HttpStatus.NOT_FOUND, "Dispositivo no encontrado"));
+        return lecturaRepository.findByDispositivoOrderByTimestampDesc(
+                dispositivo, PageRequest.of(page, size));
     }
 
     /**
-     * Obtiene las lecturas de un árbol en un rango de fechas, paginadas.
+     * Obtiene las lecturas de un dispositivo en un rango de fechas, paginadas.
      *
-     * @param arbolId identificador del árbol
-     * @param desde   inicio del rango temporal (ISO 8601)
-     * @param hasta   fin del rango temporal (ISO 8601)
-     * @param page    número de página (0-indexed, por defecto 0)
-     * @param size    tamaño de página (por defecto 20)
-     * @return página de lecturas del árbol en el rango indicado
-     * @throws ResponseStatusException si no se encuentra el árbol (404)
+     * @param dispositivoId identificador del dispositivo
+     * @param desde         inicio del rango temporal (ISO 8601)
+     * @param hasta         fin del rango temporal (ISO 8601)
+     * @param page          número de página (0-indexed, por defecto 0)
+     * @param size          tamaño de página (por defecto 20)
+     * @return página de lecturas del dispositivo en el rango indicado
+     * @throws ResponseStatusException si no se encuentra el dispositivo (404)
      */
-    @GetMapping("/arbol/{arbolId}/rango")
+    @GetMapping("/dispositivo/{dispositivoId}/rango")
     public Page<Lectura> obtenerLecturasPorRango(
-            @PathVariable("arbolId") Long arbolId,
+            @PathVariable("dispositivoId") Long dispositivoId,
             @RequestParam("desde") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime desde,
             @RequestParam("hasta") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime hasta,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
-        Arbol arbol = arbolRepository.findById(arbolId)
+        DispositivoEsp32 dispositivo = dispositivoEsp32Repository.findById(dispositivoId)
                 .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, "Árbol no encontrado"));
-        return lecturaRepository.findByArbolAndTimestampBetweenOrderByTimestampDesc(
-                arbol, desde, hasta, PageRequest.of(page, size));
+                        HttpStatus.NOT_FOUND, "Dispositivo no encontrado"));
+        return lecturaRepository.findByDispositivoAndTimestampBetweenOrderByTimestampDesc(
+                dispositivo, desde, hasta, PageRequest.of(page, size));
     }
 
     /**
@@ -161,19 +154,19 @@ public class LecturaController {
      *   <li>ANIO — últimos 365 días</li>
      * </ul>
      *
-     * @param arbolId identificador del árbol
-     * @param periodo período de tiempo a consultar
+     * @param dispositivoId identificador del dispositivo
+     * @param periodo       período de tiempo a consultar
      * @return lista de lecturas muestreadas para la gráfica
-     * @throws ResponseStatusException si no se encuentra el árbol (404) o el período es inválido (400)
+     * @throws ResponseStatusException si no se encuentra el dispositivo (404) o el período es inválido (400)
      */
-    @GetMapping("/arbol/{arbolId}/grafica")
+    @GetMapping("/dispositivo/{dispositivoId}/grafica")
     public List<LecturaMuestraProjection> obtenerLecturasParaGrafica(
-            @PathVariable("arbolId") Long arbolId,
+            @PathVariable("dispositivoId") Long dispositivoId,
             @RequestParam("periodo") String periodo) {
 
-        Arbol arbol = arbolRepository.findById(arbolId)
+        DispositivoEsp32 dispositivo = dispositivoEsp32Repository.findById(dispositivoId)
                 .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, "Árbol no encontrado"));
+                        HttpStatus.NOT_FOUND, "Dispositivo no encontrado"));
 
         LocalDateTime hasta = LocalDateTime.now();
         LocalDateTime desde = switch (periodo.toUpperCase()) {
@@ -187,6 +180,6 @@ public class LecturaController {
                     ". Valores aceptados: DIA, SEMANA, MES, SEMESTRE, ANIO");
         };
 
-        return lecturaRepository.findMuestraByArbolAndRango(arbol.getId(), desde, hasta);
+        return lecturaRepository.findMuestraByDispositivoAndRango(dispositivo.getId(), desde, hasta);
     }
 }

--- a/backend/src/main/java/com/example/gardenmonitor/model/Alerta.java
+++ b/backend/src/main/java/com/example/gardenmonitor/model/Alerta.java
@@ -21,7 +21,7 @@ import java.time.LocalDateTime;
  */
 @Entity
 @Table(name = "alerta", indexes = {
-        @Index(name = "idx_alerta_arbol", columnList = "arbol_id"),
+        @Index(name = "idx_alerta_dispositivo", columnList = "dispositivo_id"),
         @Index(name = "idx_alerta_estado", columnList = "estado"),
         @Index(name = "idx_alerta_timestamp", columnList = "timestamp")
 })
@@ -33,17 +33,17 @@ public class Alerta {
     private Long id;
 
     /**
-     * Árbol al que pertenece esta alerta.
+     * Dispositivo ESP32 al que pertenece esta alerta.
      * <p>
-     * Relación Many-to-One: un árbol puede generar múltiples alertas.
-     * Si se elimina el árbol, se eliminan en cascada todas sus alertas.
+     * Relación Many-to-One: un dispositivo puede generar múltiples alertas.
+     * Si se elimina el dispositivo, se eliminan en cascada todas sus alertas.
+     * Nullable para preservar alertas históricas sin dispositivo asignado.
      * </p>
      */
-    @NotNull
     @ManyToOne
-    @JoinColumn(name = "arbol_id", nullable = false)
+    @JoinColumn(name = "dispositivo_id")
     @OnDelete(action = OnDeleteAction.CASCADE)
-    private Arbol arbol;
+    private DispositivoEsp32 dispositivo;
 
     /**
      * Tipo de alerta según el sensor o condición que la originó.
@@ -109,8 +109,8 @@ public class Alerta {
      * @param tipoAlerta tipo de condición que disparó la alerta
      * @param mensaje    descripción detallada de la alerta
      */
-    public Alerta(Arbol arbol, TipoAlerta tipoAlerta, String mensaje) {
-        this.arbol = arbol;
+    public Alerta(DispositivoEsp32 dispositivo, TipoAlerta tipoAlerta, String mensaje) {
+        this.dispositivo = dispositivo;
         this.tipoAlerta = tipoAlerta;
         this.mensaje = mensaje;
         this.estado = EstadoAlerta.ACTIVA;
@@ -133,7 +133,7 @@ public class Alerta {
     }
 
     public Long getId() { return id; }
-    public Arbol getArbol() { return arbol; }
+    public DispositivoEsp32 getDispositivo() { return dispositivo; }
     public TipoAlerta getTipoAlerta() { return tipoAlerta; }
     public LocalDateTime getTimestamp() { return timestamp; }
     public String getMensaje() { return mensaje; }
@@ -141,7 +141,7 @@ public class Alerta {
     public LocalDateTime getFechaResolucion() { return fechaResolucion; }
 
     public void setId(Long id) { this.id = id; }
-    public void setArbol(Arbol arbol) { this.arbol = arbol; }
+    public void setDispositivo(DispositivoEsp32 dispositivo) { this.dispositivo = dispositivo; }
     public void setTipoAlerta(TipoAlerta tipoAlerta) { this.tipoAlerta = tipoAlerta; }
     public void setTimestamp(LocalDateTime timestamp) { this.timestamp = timestamp; }
     public void setMensaje(String mensaje) { this.mensaje = mensaje; }
@@ -155,7 +155,7 @@ public class Alerta {
     public String toString() {
         return "Alerta{" +
                 "id=" + id +
-                ", arbolId=" + (arbol != null ? arbol.getId() : null) +
+                ", dispositivoId=" + (dispositivo != null ? dispositivo.getId() : null) +
                 ", tipoAlerta=" + tipoAlerta +
                 ", timestamp=" + timestamp +
                 ", estado=" + estado +

--- a/backend/src/main/java/com/example/gardenmonitor/model/Arbol.java
+++ b/backend/src/main/java/com/example/gardenmonitor/model/Arbol.java
@@ -7,7 +7,6 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -18,7 +17,7 @@ import jakarta.validation.constraints.Past;
  * <p>
  * Esta clase mapea la tabla 'arbol' de la base de datos PostgreSQL
  * y almacena información de los árboles monitorizados en los centros educativos,
- * incluyendo datos de plantación, umbrales de alertas y asociación con dispositivos ESP32.
+ * incluyendo datos de plantación y absorción de CO2.
  * </p>
  *
  * @author Richard Ortiz y Enrique Pérez
@@ -71,32 +70,6 @@ public class Arbol {
     @Column(name = "ubicacion_especifica", length = 200)
     private String ubicacionEspecifica;
 
-    @Column(name = "umbral_temp_min", columnDefinition = "DECIMAL(5,2) DEFAULT 5.00")
-    @DecimalMin(value = "-15")
-    private BigDecimal umbralTempMin;
-
-    @Column(name = "umbral_temp_max", columnDefinition = "DECIMAL(5,2) DEFAULT 40.00")
-    @DecimalMax(value = "45")
-    private BigDecimal umbralTempMax;
-
-    @Column(name = "umbral_humedad_ambiente_min", columnDefinition = "DECIMAL(5,2) DEFAULT 30.00")
-    @DecimalMin(value = "0.01")
-    @DecimalMax(value = "100")
-    private BigDecimal umbralHumedadAmbienteMin;
-
-    @Column(name = "umbral_humedad_ambiente_max", columnDefinition = "DECIMAL(5,2) DEFAULT 90.00")
-    @DecimalMin(value = "0.01")
-    @DecimalMax(value = "100")
-    private BigDecimal umbralHumedadAmbienteMax;
-
-    @Column(name = "umbral_humedad_suelo_min", columnDefinition = "DECIMAL(5,2) DEFAULT 30.00")
-    @DecimalMin(value = "0.01")
-    @DecimalMax(value = "100")
-    private BigDecimal umbralHumedadSueloMin;
-
-    @Column(name = "umbral_co2_max", columnDefinition = "DECIMAL(5,2) DEFAULT 1000.00")
-    private BigDecimal umbralCO2Max;
-
     @Column(name = "absorcion_co2_anual", columnDefinition = "DECIMAL(8,2)")
     @DecimalMin(value = "0")
     private BigDecimal absorcionCo2Anual;
@@ -118,37 +91,19 @@ public class Arbol {
      * @param especie especie del árbol (máx 150 caracteres)
      * @param fechaPlantacion fecha de plantación (debe ser en el pasado)
      * @param ubicacionEspecifica ubicación específica dentro del centro (máx 200 caracteres)
-     * @param umbralTempMin temperatura mínima de alerta (rango: -15 a 45°C)
-     * @param umbralTempMax temperatura máxima de alerta (rango: -15 a 45°C)
-     * @param umbralHumedadAmbienteMin humedad ambiente mínima de alerta (rango: 0.01 a 100%)
-     * @param umbralHumedadAmbienteMax humedad ambiente máxima de alerta (rango: 0.01 a 100%)
-     * @param umbralHumedadSueloMin humedad de suelo mínima de alerta (rango: 0.01 a 100%)
-     * @param umbralCO2Max nivel máximo de CO2 de alerta (ppm)
      */
     public Arbol(
             CentroEducativo centroEducativo,
             String nombre,
             String especie,
             LocalDate fechaPlantacion,
-            String ubicacionEspecifica,
-            BigDecimal umbralTempMin,
-            BigDecimal umbralTempMax,
-            BigDecimal umbralHumedadAmbienteMin,
-            BigDecimal umbralHumedadAmbienteMax,
-            BigDecimal umbralHumedadSueloMin,
-            BigDecimal umbralCO2Max) {
+            String ubicacionEspecifica) {
 
         this.centroEducativo = centroEducativo;
         this.nombre = nombre;
         this.especie = especie;
         this.fechaPlantacion = fechaPlantacion;
         this.ubicacionEspecifica = ubicacionEspecifica;
-        this.umbralTempMin = umbralTempMin;
-        this.umbralTempMax = umbralTempMax;
-        this.umbralHumedadAmbienteMin = umbralHumedadAmbienteMin;
-        this.umbralHumedadAmbienteMax = umbralHumedadAmbienteMax;
-        this.umbralHumedadSueloMin = umbralHumedadSueloMin;
-        this.umbralCO2Max = umbralCO2Max;
     }
 
     public Long getId() {
@@ -175,30 +130,6 @@ public class Arbol {
         return ubicacionEspecifica;
     }
 
-    public BigDecimal getUmbralTempMin() {
-        return umbralTempMin;
-    }
-
-    public BigDecimal getUmbralTempMax() {
-        return umbralTempMax;
-    }
-
-    public BigDecimal getUmbralHumedadAmbienteMin() {
-        return umbralHumedadAmbienteMin;
-    }
-
-    public BigDecimal getUmbralHumedadAmbienteMax() {
-        return umbralHumedadAmbienteMax;
-    }
-
-    public BigDecimal getUmbralHumedadSueloMin() {
-        return umbralHumedadSueloMin;
-    }
-
-    public BigDecimal getUmbralCO2Max() {
-        return umbralCO2Max;
-    }
-
     public BigDecimal getAbsorcionCo2Anual() {
         return absorcionCo2Anual;
     }
@@ -221,30 +152,6 @@ public class Arbol {
 
     public void setUbicacionEspecifica(String ubicacionEspecifica) {
         this.ubicacionEspecifica = ubicacionEspecifica;
-    }
-
-    public void setUmbralTempMin(BigDecimal umbralTempMin) {
-        this.umbralTempMin = umbralTempMin;
-    }
-
-    public void setUmbralTempMax(BigDecimal umbralTempMax) {
-        this.umbralTempMax = umbralTempMax;
-    }
-
-    public void setUmbralHumedadAmbienteMin(BigDecimal umbralHumedadAmbienteMin) {
-        this.umbralHumedadAmbienteMin = umbralHumedadAmbienteMin;
-    }
-
-    public void setUmbralHumedadAmbienteMax(BigDecimal umbralHumedadAmbienteMax) {
-        this.umbralHumedadAmbienteMax = umbralHumedadAmbienteMax;
-    }
-
-    public void setUmbralHumedadSueloMin(BigDecimal umbralHumedadSueloMin) {
-        this.umbralHumedadSueloMin = umbralHumedadSueloMin;
-    }
-
-    public void setUmbralCO2Max(BigDecimal umbralCO2Max) {
-        this.umbralCO2Max = umbralCO2Max;
     }
 
     public void setAbsorcionCo2Anual(BigDecimal absorcionCo2Anual) {

--- a/backend/src/main/java/com/example/gardenmonitor/model/Arbol.java
+++ b/backend/src/main/java/com/example/gardenmonitor/model/Arbol.java
@@ -28,7 +28,6 @@ import jakarta.validation.constraints.Past;
 @Entity
 @Table(name = "arbol", indexes = {
         @Index(name = "idx_arbol_centro", columnList = "centro_id"),
-        @Index(name = "idx_arbol_dispositivo_esp32", columnList = "dispositivo_id"),
         @Index(name = "idx_arbol_especie", columnList = "especie")
 })
 public class Arbol {
@@ -71,17 +70,6 @@ public class Arbol {
 
     @Column(name = "ubicacion_especifica", length = 200)
     private String ubicacionEspecifica;
-
-    /**
-     * Dispositivo ESP32 asociado al árbol para monitorización.
-     * <p>
-     * Relación One-to-One: un árbol tiene un único dispositivo.
-     * Si se elimina el dispositivo, se establece a NULL (ON DELETE SET NULL).
-     * </p>
-     */
-    @OneToOne
-    @JoinColumn(name = "dispositivo_id", foreignKey = @ForeignKey(name = "fk_dispositivo_esp32", foreignKeyDefinition = "FOREIGN KEY (dispositivo_id) REFERENCES dispositivo_esp32(id) ON DELETE SET NULL"))
-    private DispositivoEsp32 dispositivoEsp32;
 
     @Column(name = "umbral_temp_min", columnDefinition = "DECIMAL(5,2) DEFAULT 5.00")
     @DecimalMin(value = "-15")
@@ -130,7 +118,6 @@ public class Arbol {
      * @param especie especie del árbol (máx 150 caracteres)
      * @param fechaPlantacion fecha de plantación (debe ser en el pasado)
      * @param ubicacionEspecifica ubicación específica dentro del centro (máx 200 caracteres)
-     * @param dispositivoEsp32 dispositivo ESP32 asociado (puede ser null)
      * @param umbralTempMin temperatura mínima de alerta (rango: -15 a 45°C)
      * @param umbralTempMax temperatura máxima de alerta (rango: -15 a 45°C)
      * @param umbralHumedadAmbienteMin humedad ambiente mínima de alerta (rango: 0.01 a 100%)
@@ -144,7 +131,6 @@ public class Arbol {
             String especie,
             LocalDate fechaPlantacion,
             String ubicacionEspecifica,
-            DispositivoEsp32 dispositivoEsp32,
             BigDecimal umbralTempMin,
             BigDecimal umbralTempMax,
             BigDecimal umbralHumedadAmbienteMin,
@@ -157,7 +143,6 @@ public class Arbol {
         this.especie = especie;
         this.fechaPlantacion = fechaPlantacion;
         this.ubicacionEspecifica = ubicacionEspecifica;
-        this.dispositivoEsp32 = dispositivoEsp32;
         this.umbralTempMin = umbralTempMin;
         this.umbralTempMax = umbralTempMax;
         this.umbralHumedadAmbienteMin = umbralHumedadAmbienteMin;
@@ -188,10 +173,6 @@ public class Arbol {
 
     public String getUbicacionEspecifica() {
         return ubicacionEspecifica;
-    }
-
-    public DispositivoEsp32 getDispositivoEsp32() {
-        return dispositivoEsp32;
     }
 
     public BigDecimal getUmbralTempMin() {
@@ -240,10 +221,6 @@ public class Arbol {
 
     public void setUbicacionEspecifica(String ubicacionEspecifica) {
         this.ubicacionEspecifica = ubicacionEspecifica;
-    }
-
-    public void setDispositivoEsp32(DispositivoEsp32 dispositivoEsp32) {
-        this.dispositivoEsp32 = dispositivoEsp32;
     }
 
     public void setUmbralTempMin(BigDecimal umbralTempMin) {

--- a/backend/src/main/java/com/example/gardenmonitor/model/DispositivoEsp32.java
+++ b/backend/src/main/java/com/example/gardenmonitor/model/DispositivoEsp32.java
@@ -3,8 +3,11 @@ package com.example.gardenmonitor.model;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 /**
@@ -79,6 +82,32 @@ public class DispositivoEsp32 {
     @Column(name = "frecuencia_lectura_seg", columnDefinition = "INTEGER DEFAULT 30")
     private int frecuenciaLecturaSeg;
 
+    @Column(name = "umbral_temp_min", columnDefinition = "DECIMAL(5,2) DEFAULT 5.00")
+    @DecimalMin(value = "-15")
+    private BigDecimal umbralTempMin;
+
+    @Column(name = "umbral_temp_max", columnDefinition = "DECIMAL(5,2) DEFAULT 40.00")
+    @DecimalMax(value = "45")
+    private BigDecimal umbralTempMax;
+
+    @Column(name = "umbral_humedad_ambiente_min", columnDefinition = "DECIMAL(5,2) DEFAULT 30.00")
+    @DecimalMin(value = "0.01")
+    @DecimalMax(value = "100")
+    private BigDecimal umbralHumedadAmbienteMin;
+
+    @Column(name = "umbral_humedad_ambiente_max", columnDefinition = "DECIMAL(5,2) DEFAULT 90.00")
+    @DecimalMin(value = "0.01")
+    @DecimalMax(value = "100")
+    private BigDecimal umbralHumedadAmbienteMax;
+
+    @Column(name = "umbral_humedad_suelo_min", columnDefinition = "DECIMAL(5,2) DEFAULT 30.00")
+    @DecimalMin(value = "0.01")
+    @DecimalMax(value = "100")
+    private BigDecimal umbralHumedadSueloMin;
+
+    @Column(name = "umbral_co2_max", columnDefinition = "DECIMAL(7,2) DEFAULT 1000.00")
+    private BigDecimal umbralCO2Max;
+
     /**
      * Constructor vacío requerido por JPA.
      */
@@ -109,12 +138,25 @@ public class DispositivoEsp32 {
     public LocalDateTime getUltimaConexion() {return ultimaConexion;}
     public int getFrecuenciaLecturaSeg() {return frecuenciaLecturaSeg;}
 
+    public BigDecimal getUmbralTempMin() {return umbralTempMin;}
+    public BigDecimal getUmbralTempMax() {return umbralTempMax;}
+    public BigDecimal getUmbralHumedadAmbienteMin() {return umbralHumedadAmbienteMin;}
+    public BigDecimal getUmbralHumedadAmbienteMax() {return umbralHumedadAmbienteMax;}
+    public BigDecimal getUmbralHumedadSueloMin() {return umbralHumedadSueloMin;}
+    public BigDecimal getUmbralCO2Max() {return umbralCO2Max;}
+
     public void setId(Long id) {this.id = id;}
     public void setMacAddress(String macAddress) {this.macAddress = macAddress;}
     public void setCentroEducativo(CentroEducativo centroEducativo) {this.centroEducativo = centroEducativo;}
     public void setActivo(boolean activo) {this.activo = activo;}
     public void setUltimaConexion(LocalDateTime ultimaConexion) {this.ultimaConexion = ultimaConexion;}
     public void setFrecuenciaLecturaSeg(int frecuenciaLecturaSeg) {this.frecuenciaLecturaSeg = frecuenciaLecturaSeg;}
+    public void setUmbralTempMin(BigDecimal umbralTempMin) {this.umbralTempMin = umbralTempMin;}
+    public void setUmbralTempMax(BigDecimal umbralTempMax) {this.umbralTempMax = umbralTempMax;}
+    public void setUmbralHumedadAmbienteMin(BigDecimal umbralHumedadAmbienteMin) {this.umbralHumedadAmbienteMin = umbralHumedadAmbienteMin;}
+    public void setUmbralHumedadAmbienteMax(BigDecimal umbralHumedadAmbienteMax) {this.umbralHumedadAmbienteMax = umbralHumedadAmbienteMax;}
+    public void setUmbralHumedadSueloMin(BigDecimal umbralHumedadSueloMin) {this.umbralHumedadSueloMin = umbralHumedadSueloMin;}
+    public void setUmbralCO2Max(BigDecimal umbralCO2Max) {this.umbralCO2Max = umbralCO2Max;}
 
     /**
      * Callback ejecutado antes de persistir un nuevo dispositivo ESP32 en la base de datos.

--- a/backend/src/main/java/com/example/gardenmonitor/model/DispositivoEsp32.java
+++ b/backend/src/main/java/com/example/gardenmonitor/model/DispositivoEsp32.java
@@ -1,7 +1,9 @@
 package com.example.gardenmonitor.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import java.time.LocalDateTime;
 
@@ -19,7 +21,8 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "dispositivo_esp32", indexes = {
-        @Index(name = "idx_dispositivo_esp32_activo", columnList = "activo")
+        @Index(name = "idx_dispositivo_esp32_activo", columnList = "activo"),
+        @Index(name = "idx_dispositivo_centro", columnList = "centro_id")
 })
 public class DispositivoEsp32 {
 
@@ -40,14 +43,17 @@ public class DispositivoEsp32 {
     private String macAddress;
 
     /**
-     * Árbol asociado al dispositivo ESP32.
+     * Centro educativo al que pertenece este dispositivo ESP32.
      * <p>
-     * Relación One-to-One bidireccional: un dispositivo monitoriza un único árbol.
+     * Relación Many-to-One: un centro puede tener varios dispositivos.
+     * Si se elimina el centro, se eliminan en cascada todos sus dispositivos.
      * </p>
      */
-    @JsonIgnore
-    @OneToOne(mappedBy = "dispositivoEsp32")
-    private Arbol arbol;
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "centro_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private CentroEducativo centroEducativo;
 
     @Column(name = "activo", nullable = false, columnDefinition = "BOOLEAN DEFAULT true")
     private boolean activo;
@@ -85,27 +91,27 @@ public class DispositivoEsp32 {
      * </p>
      *
      * @param macAddress dirección MAC del dispositivo (formato XX:XX:XX:XX:XX:XX)
-     * @param arbol árbol asociado al dispositivo (puede ser null)
+     * @param centroEducativo centro educativo al que pertenece el dispositivo
      * @param activo indica si el dispositivo está activo
      * @param frecuenciaLecturaSeg frecuencia de lectura en segundos (por defecto 30)
      */
-    public DispositivoEsp32(String macAddress, Arbol arbol, boolean activo, int frecuenciaLecturaSeg) {
+    public DispositivoEsp32(String macAddress, CentroEducativo centroEducativo, boolean activo, int frecuenciaLecturaSeg) {
         this.macAddress = macAddress;
-        this.arbol = arbol;
+        this.centroEducativo = centroEducativo;
         this.activo = activo;
         this.frecuenciaLecturaSeg = frecuenciaLecturaSeg;
     }
 
     public Long getId() {return id;}
     public String getMacAddress() {return macAddress;}
-    public Arbol getArbol() {return arbol;}
+    public CentroEducativo getCentroEducativo() {return centroEducativo;}
     public boolean isActivo() {return activo;}
     public LocalDateTime getUltimaConexion() {return ultimaConexion;}
     public int getFrecuenciaLecturaSeg() {return frecuenciaLecturaSeg;}
 
     public void setId(Long id) {this.id = id;}
     public void setMacAddress(String macAddress) {this.macAddress = macAddress;}
-    public void setArbol(Arbol arbol) {this.arbol = arbol;}
+    public void setCentroEducativo(CentroEducativo centroEducativo) {this.centroEducativo = centroEducativo;}
     public void setActivo(boolean activo) {this.activo = activo;}
     public void setUltimaConexion(LocalDateTime ultimaConexion) {this.ultimaConexion = ultimaConexion;}
     public void setFrecuenciaLecturaSeg(int frecuenciaLecturaSeg) {this.frecuenciaLecturaSeg = frecuenciaLecturaSeg;}

--- a/backend/src/main/java/com/example/gardenmonitor/model/Lectura.java
+++ b/backend/src/main/java/com/example/gardenmonitor/model/Lectura.java
@@ -29,7 +29,6 @@ import jakarta.validation.constraints.NotNull;
  */
 @Entity
 @Table(name = "lectura", indexes = {
-        @Index(name = "idx_lectura_arbol_timestamp", columnList = "arbol_id, timestamp DESC"),
         @Index(name = "idx_lectura_dispositivo_timestamp", columnList = "dispositivo_id, timestamp DESC")
 })
 public class Lectura {
@@ -50,18 +49,6 @@ public class Lectura {
     @NotNull
     @Column(name = "timestamp", nullable = false, columnDefinition = "TIMESTAMPTZ")
     private LocalDateTime timestamp;
-
-    /**
-     * Árbol asociado a esta lectura.
-     * <p>
-     * Relación Many-to-One: un árbol genera muchas lecturas.
-     * Si se elimina el árbol, se eliminan en cascada todas sus lecturas.
-     * </p>
-     */
-    @ManyToOne
-    @JoinColumn(name = "arbol_id", nullable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
-    private Arbol arbol;
 
     /**
      * Dispositivo ESP32 que envió esta lectura.
@@ -115,7 +102,6 @@ public class Lectura {
 
     public Long getId() { return id; }
     public LocalDateTime getTimestamp() { return timestamp; }
-    public Arbol getArbol() { return arbol; }
     public DispositivoEsp32 getDispositivo() { return dispositivo; }
     public BigDecimal getTemperatura() { return temperatura; }
     public BigDecimal getHumedadAmbiente() { return humedadAmbiente; }
@@ -126,7 +112,6 @@ public class Lectura {
 
     public void setId(Long id) { this.id = id; }
     public void setTimestamp(LocalDateTime timestamp) { this.timestamp = timestamp; }
-    public void setArbol(Arbol arbol) { this.arbol = arbol; }
     public void setDispositivo(DispositivoEsp32 dispositivo) { this.dispositivo = dispositivo; }
     public void setTemperatura(BigDecimal temperatura) { this.temperatura = temperatura; }
     public void setHumedadAmbiente(BigDecimal humedadAmbiente) { this.humedadAmbiente = humedadAmbiente; }
@@ -143,7 +128,6 @@ public class Lectura {
         return "Lectura{" +
                 "id=" + id +
                 ", timestamp=" + timestamp +
-                ", arbolId=" + (arbol != null ? arbol.getId() : null) +
                 ", dispositivoId=" + (dispositivo != null ? dispositivo.getId() : null) +
                 ", temperatura=" + temperatura +
                 ", humedadAmbiente=" + humedadAmbiente +

--- a/backend/src/main/java/com/example/gardenmonitor/repository/AlertaRepository.java
+++ b/backend/src/main/java/com/example/gardenmonitor/repository/AlertaRepository.java
@@ -1,7 +1,6 @@
 package com.example.gardenmonitor.repository;
 
 import com.example.gardenmonitor.model.Alerta;
-import com.example.gardenmonitor.model.Arbol;
 import com.example.gardenmonitor.model.EstadoAlerta;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,8 +9,7 @@ import java.util.List;
 
 @Repository
 public interface AlertaRepository extends JpaRepository<Alerta, Long> {
-    List<Alerta> findByArbol(Arbol arbol);
-    List<Alerta> findByArbol_Id(Long arbolId);
+    List<Alerta> findByDispositivo_Id(Long dispositivoId);
     List<Alerta> findByEstado(EstadoAlerta estado);
-    List<Alerta> findByArbol_IdAndEstado(Long arbolId, EstadoAlerta estado);
+    List<Alerta> findByDispositivo_IdAndEstado(Long dispositivoId, EstadoAlerta estado);
 }

--- a/backend/src/main/java/com/example/gardenmonitor/repository/ArbolRepository.java
+++ b/backend/src/main/java/com/example/gardenmonitor/repository/ArbolRepository.java
@@ -1,20 +1,17 @@
 package com.example.gardenmonitor.repository;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.example.gardenmonitor.model.Arbol;
 import com.example.gardenmonitor.model.CentroEducativo;
-import com.example.gardenmonitor.model.DispositivoEsp32;
 
 @Repository
 public interface ArbolRepository extends JpaRepository<Arbol, Long>{
     List<Arbol> findByEspecie(String especie);
     List<Arbol> findByCentroEducativo(CentroEducativo centroEducativo);
-    Optional<Arbol> findByDispositivoEsp32(DispositivoEsp32 dispositivoEsp32);
     List<Arbol> findByNombreContainingIgnoreCase(String nombre);
     List<Arbol> findAllByOrderByNombreAsc();
     boolean existsByNombreAndCentroEducativo(String nombre, CentroEducativo centroEducacion);

--- a/backend/src/main/java/com/example/gardenmonitor/repository/DispositivoEsp32Repository.java
+++ b/backend/src/main/java/com/example/gardenmonitor/repository/DispositivoEsp32Repository.java
@@ -7,13 +7,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.example.gardenmonitor.model.DispositivoEsp32;
-import com.example.gardenmonitor.model.Arbol;
 
 
 @Repository
 public interface DispositivoEsp32Repository extends JpaRepository<DispositivoEsp32, Long>{
     Optional<DispositivoEsp32> findByMacAddress(String macAddress);
     boolean existsByMacAddress(String macAddress);
-    Optional<DispositivoEsp32> findByArbol(Arbol arbol);
     List<DispositivoEsp32> findByActivo(boolean activo);
+    List<DispositivoEsp32> findByCentroEducativo_Id(Long centroId);
 }

--- a/backend/src/main/java/com/example/gardenmonitor/repository/LecturaRepository.java
+++ b/backend/src/main/java/com/example/gardenmonitor/repository/LecturaRepository.java
@@ -1,7 +1,6 @@
 package com.example.gardenmonitor.repository;
 
 import com.example.gardenmonitor.dto.LecturaMuestraProjection;
-import com.example.gardenmonitor.model.Arbol;
 import com.example.gardenmonitor.model.DispositivoEsp32;
 import com.example.gardenmonitor.model.Lectura;
 import org.springframework.data.domain.Page;
@@ -15,12 +14,10 @@ import java.util.List;
 
 public interface LecturaRepository extends JpaRepository<Lectura, Long> {
 
-    Page<Lectura> findByArbolOrderByTimestampDesc(Arbol arbol, Pageable pageable);
+    Page<Lectura> findByDispositivoOrderByTimestampDesc(DispositivoEsp32 dispositivo, Pageable pageable);
 
-    List<Lectura> findByDispositivoOrderByTimestampDesc(DispositivoEsp32 dispositivo);
-
-    Page<Lectura> findByArbolAndTimestampBetweenOrderByTimestampDesc(
-            Arbol arbol, LocalDateTime desde, LocalDateTime hasta, Pageable pageable);
+    Page<Lectura> findByDispositivoAndTimestampBetweenOrderByTimestampDesc(
+            DispositivoEsp32 dispositivo, LocalDateTime desde, LocalDateTime hasta, Pageable pageable);
 
     /**
      * Stride sampling: devuelve lecturas REALES (sin promedios) garantizando
@@ -47,7 +44,7 @@ public interface LecturaRepository extends JpaRepository<Lectura, Long> {
                        ROW_NUMBER() OVER (ORDER BY l.timestamp ASC) AS rn,
                        COUNT(*)     OVER ()                          AS total_count
                 FROM lectura l
-                WHERE l.arbol_id = :arbolId
+                WHERE l.dispositivo_id = :dispositivoId
                   AND l.timestamp >= :desde
                   AND l.timestamp <= :hasta
             )
@@ -58,8 +55,8 @@ public interface LecturaRepository extends JpaRepository<Lectura, Long> {
                OR rn = total_count
             ORDER BY timestamp ASC
             """, nativeQuery = true)
-    List<LecturaMuestraProjection> findMuestraByArbolAndRango(
-            @Param("arbolId") Long arbolId,
+    List<LecturaMuestraProjection> findMuestraByDispositivoAndRango(
+            @Param("dispositivoId") Long dispositivoId,
             @Param("desde") LocalDateTime desde,
             @Param("hasta") LocalDateTime hasta);
 }

--- a/docs/02. HOJA_DE_RUTA.md
+++ b/docs/02. HOJA_DE_RUTA.md
@@ -1,7 +1,7 @@
 # Hoja de Ruta - Proyecto Árboles
 
-**Última actualización**: 2026-02-22
-**Estado**: [x] Fase 1-7 COMPLETADAS | [x] DESPLIEGUE COMPLETADO | [x] Fase 9 Testing COMPLETADA | [x] Fase 11 PUT N:M COMPLETADA | [x] Fase 14 CRUD entidades COMPLETADA | [ ] Fases 12-13-15 Pendientes 2ª Evaluación
+**Última actualización**: 2026-04-11
+**Estado**: [x] Fase 1-7 COMPLETADAS | [x] DESPLIEGUE COMPLETADO | [x] Fase 9 Testing COMPLETADA | [x] Fase 11 PUT N:M COMPLETADA | [x] Fase 14 CRUD entidades COMPLETADA | [x] Refactor Dispositivo-Centro COMPLETADO | [ ] Fases 12-13-15 Pendientes 2ª Evaluación
 
 ---
 
@@ -56,11 +56,13 @@
 
 **2ª evaluación — Pantallas:**
 - [x] Login y Register funcionales (auth real contra BD)
-- [x] Mínimo 6 pantallas sin contar login/register (tenemos 8)
+- [x] Mínimo 6 pantallas sin contar login/register (tenemos 10+)
 - [x] Dashboard/Inicio
-- [x] Listado + Detalle + Crear/Editar árbol
-- [x] Gestión secundaria (centros educativos)
+- [x] Listado + Detalle + Crear/Editar árbol (inventario)
+- [x] Gestión secundaria (centros educativos con sus dispositivos ESP32)
 - [x] Página de administración solo ADMIN (gestión de usuarios)
+- [x] Histórico de lecturas por dispositivo (gráficas + tabla paginada)
+- [x] Crear/Editar dispositivo ESP32 (con umbrales de monitorización)
 - [x] Todas las pantallas con contenido real
 
 **2ª evaluación — Testing:**
@@ -154,7 +156,7 @@
 - [x] Entidades JPA: Usuario, CentroEducativo, Arbol, DispositivoEsp32
 - [x] Repositorios JPA
 - [x] Relación 1:N: CentroEducativo → Arbol
-- [x] Relación 1:1: Arbol ↔ DispositivoEsp32
+- [x] Relación 1:N: CentroEducativo → DispositivoEsp32 (refactorizado — ver fase "Refactor Dispositivo-Centro")
 
 ---
 
@@ -563,6 +565,22 @@
 
 ---
 
+### Refactor Dispositivo-Centro [x]
+
+> Cada `DispositivoEsp32` pertenece a un `CentroEducativo`. Los umbrales de monitorización se trasladan del árbol al dispositivo. Los árboles actúan como inventario del centro.
+
+- [x] **Backend — Modelo**: `DispositivoEsp32` con relación `@ManyToOne` a `CentroEducativo` y campos `umbralTempMin/Max`, `umbralHumedadAmbienteMin/Max`, `umbralHumedadSueloMin`, `umbralCO2Max`
+- [x] **Backend — DispositivoEsp32Controller**: `GET /api/dispositivos/centro/{id}` + `PATCH /{id}/umbrales` (actualización parcial)
+- [x] **Backend — Migración**: `migration_dispositivo_centro.sql` idempotente (IF NOT EXISTS / IF EXISTS) — aplicada en local y producción
+- [x] **Frontend — DetalleCentro**: sección "Dispositivos ESP32" con tabla, modal de eliminación y accesos a histórico y formulario
+- [x] **Frontend — FormularioDispositivo**: alta/edición con validación MAC (`XX:XX:XX:XX:XX:XX`), frecuencia (5-3600 s) y umbrales opcionales
+- [x] **Frontend — HistoricoDispositivo**: gráficas de sensores y CO2 + tabla paginada + polling por `frecuencia_lectura_seg`
+- [x] **Frontend — DetalleArbol**: información de inventario (nombre, especie, fecha, ubicación, absorción CO2)
+- [x] **Frontend — dispositivosService.js**: CRUD completo para `/api/dispositivos`
+- [x] **Frontend — lecturasService.js**: endpoints actualizados a `/api/lecturas/dispositivo/{id}`
+
+---
+
 ## Información del Proyecto
 
 **Nombre**: Proyecto Árboles - Sistema de Monitorización de Árboles
@@ -573,7 +591,7 @@
 
 **Repositorio**: [github.com/riordi80/vocational-training-final-project](https://github.com/riordi80/vocational-training-final-project)
 
-**Última actualización**: 2026-02-22
+**Última actualización**: 2026-04-11
 
 ### Colaboradores
 

--- a/docs/03. ESPECIFICACION_TECNICA.md
+++ b/docs/03. ESPECIFICACION_TECNICA.md
@@ -241,12 +241,13 @@ Para ver el modelo de datos completo, consulta [04. MODELO_DATOS.md](./04.%20MOD
 - El sistema debe permitir CRUD completo de árboles
 - Cada árbol debe asociarse obligatoriamente a un centro educativo
 - El sistema debe almacenar: nombre, especie, fecha de plantación, ubicación específica
-- El sistema debe permitir configurar umbrales de alerta por árbol
+- El sistema debe almacenar información de absorción de CO2 por árbol
 - El sistema debe validar que la fecha de plantación no sea futura
 
 #### RF-03: Gestión de Dispositivos IoT
 - El sistema debe registrar dispositivos ESP32 con MAC address única
-- El sistema debe permitir asociar un dispositivo a un árbol (relación 1:1)
+- Cada dispositivo pertenece a un centro educativo (relación N:1)
+- El sistema debe permitir configurar umbrales de alerta por dispositivo
 - El sistema debe registrar la última conexión de cada dispositivo
 
 #### RF-04: Monitorización de Datos Ambientales

--- a/docs/04. MODELO_DATOS.md
+++ b/docs/04. MODELO_DATOS.md
@@ -1,7 +1,8 @@
 # Modelo de Datos - Proyecto Árboles (Proyecto Árboles)
 
 **Fecha de creación**: 2025-11-15
-**Versión**: 1.0
+**Última actualización**: 2026-04-11
+**Versión**: 2.0
 **Requisito**: AED - Acceso a Datos
 
 ---
@@ -36,9 +37,9 @@ El sistema gestiona 8 entidades principales:
 ### Relaciones principales:
 
 - **1:N** - Un CentroEducativo tiene muchos Arboles
-- **1:1** - Un Arbol tiene un DispositivoESP32
-- **1:N** - Un Arbol genera muchas Lecturas
-- **1:N** - Un Arbol puede tener muchas Alertas
+- **1:N** - Un CentroEducativo tiene muchos DispositivoESP32
+- **1:N** - Un DispositivoESP32 genera muchas Lecturas
+- **1:N** - Un DispositivoESP32 puede tener muchas Alertas
 - **N:M** - Usuarios ↔ CentrosEducativos (a través de UsuarioCentro)
 
 ---
@@ -50,9 +51,9 @@ erDiagram
     USUARIO ||--o{ USUARIO_CENTRO : "tiene acceso a"
     CENTRO_EDUCATIVO ||--o{ USUARIO_CENTRO : "tiene usuarios"
     CENTRO_EDUCATIVO ||--o{ ARBOL : "contiene"
-    ARBOL ||--|| DISPOSITIVO_ESP32 : "monitorizado por"
-    ARBOL ||--o{ LECTURA : "genera"
-    ARBOL ||--o{ ALERTA : "puede tener"
+    CENTRO_EDUCATIVO ||--o{ DISPOSITIVO_ESP32 : "tiene"
+    DISPOSITIVO_ESP32 ||--o{ LECTURA : "genera"
+    DISPOSITIVO_ESP32 ||--o{ ALERTA : "puede tener"
     ALERTA ||--o{ NOTIFICACION : "genera"
     USUARIO ||--o{ NOTIFICACION : "recibe"
 
@@ -89,29 +90,27 @@ erDiagram
         string especie
         date fecha_plantacion
         string ubicacion_especifica
-        bigint dispositivo_id FK
-        decimal umbral_temp_min
-        decimal umbral_temp_max
-        decimal umbral_humedad_ambiente_min
-        decimal umbral_humedad_ambiente_max
-        decimal umbral_humedad_suelo_min
-        decimal umbral_co2_max
         decimal absorcion_co2_anual
     }
 
     DISPOSITIVO_ESP32 {
         bigint id PK
         string mac_address UK
-        bigint arbol_id FK
+        bigint centro_id FK
         boolean activo
         timestamptz ultima_conexion
         int frecuencia_lectura_seg
+        decimal umbral_temp_min
+        decimal umbral_temp_max
+        decimal umbral_humedad_ambiente_min
+        decimal umbral_humedad_ambiente_max
+        decimal umbral_humedad_suelo_min
+        decimal umbral_co2_max
     }
 
     LECTURA {
         bigint id PK
         timestamptz timestamp PK
-        bigint arbol_id FK
         bigint dispositivo_id FK
         decimal temperatura
         decimal humedad_ambiente
@@ -123,7 +122,7 @@ erDiagram
 
     ALERTA {
         bigint id PK
-        bigint arbol_id FK
+        bigint dispositivo_id FK
         enum tipo_alerta
         timestamptz timestamp
         string mensaje
@@ -216,30 +215,27 @@ classDiagram
         -String especie
         -LocalDate fechaPlantacion
         -String ubicacionEspecifica
-        -DispositivoESP32 dispositivo
+        -BigDecimal absorcionCo2Anual
+        +getId() Long
+        +getEspecie() String
+        +getCentro() CentroEducativo
+    }
+
+    class DispositivoESP32 {
+        -Long id
+        -String macAddress
+        -CentroEducativo centroEducativo
+        -Boolean activo
+        -LocalDateTime ultimaConexion
+        -Integer frecuenciaLecturaSeg
         -BigDecimal umbralTempMin
         -BigDecimal umbralTempMax
         -BigDecimal umbralHumedadAmbienteMin
         -BigDecimal umbralHumedadAmbienteMax
         -BigDecimal umbralHumedadSueloMin
         -BigDecimal umbralCo2Max
-        -BigDecimal absorcionCo2Anual
         -Set~Lectura~ lecturas
         -Set~Alerta~ alertas
-        +getId() Long
-        +getEspecie() String
-        +getCentro() CentroEducativo
-        +getUltimaLectura() Lectura
-    }
-
-    class DispositivoESP32 {
-        -Long id
-        -String macAddress
-        -Arbol arbol
-        -Boolean activo
-        -LocalDateTime ultimaConexion
-        -Integer frecuenciaLecturaSeg
-        -Set~Lectura~ lecturas
         +getId() Long
         +getMacAddress() String
         +isActivo() Boolean
@@ -248,7 +244,6 @@ classDiagram
     class Lectura {
         -Long id
         -LocalDateTime timestamp
-        -Arbol arbol
         -DispositivoESP32 dispositivo
         -BigDecimal temperatura
         -BigDecimal humedadAmbiente
@@ -268,7 +263,7 @@ classDiagram
 
     class Alerta {
         -Long id
-        -Arbol arbol
+        -DispositivoESP32 dispositivo
         -TipoAlerta tipo
         -LocalDateTime timestamp
         -String mensaje
@@ -328,17 +323,16 @@ classDiagram
 
     CentroEducativo --> Isla : tiene
     CentroEducativo "1" --> "*" Arbol : contiene
+    CentroEducativo "1" --> "*" DispositivoESP32 : tiene
     CentroEducativo "1" --> "*" UsuarioCentro : tiene
 
     Arbol "*" --> "1" CentroEducativo : pertenece a
-    Arbol "1" --> "1" DispositivoESP32 : monitorizado por
-    Arbol "1" --> "*" Lectura : genera
-    Arbol "1" --> "*" Alerta : tiene
 
-    DispositivoESP32 "1" --> "*" Lectura : envía
+    DispositivoESP32 "*" --> "1" CentroEducativo : pertenece a
+    DispositivoESP32 "1" --> "*" Lectura : genera
+    DispositivoESP32 "1" --> "*" Alerta : tiene
 
-
-    Alerta "*" --> "1" Arbol : pertenece a
+    Alerta "*" --> "1" DispositivoESP32 : pertenece a
     Alerta --> TipoAlerta : tiene
     Alerta --> EstadoAlerta : tiene
     Alerta "1" --> "*" Notificacion : genera
@@ -403,7 +397,7 @@ classDiagram
 
 ### 3. Tabla: `arbol`
 
-**Descripción**: Árboles monitorizados en los centros educativos.
+**Descripción**: Inventario de árboles plantados en los centros educativos.
 
 | Campo | Tipo | Restricciones | Descripción |
 |-------|------|---------------|-------------|
@@ -413,20 +407,11 @@ classDiagram
 | `especie` | VARCHAR(150) | NOT NULL | Especie del árbol |
 | `fecha_plantacion` | DATE | NOT NULL | Fecha de plantación |
 | `ubicacion_especifica` | VARCHAR(200) | NULL | Ubicación dentro del centro |
-| `dispositivo_id` | BIGINT | NULL, FOREIGN KEY UNIQUE | Referencia a dispositivo_esp32 |
-| `umbral_temp_min` | DECIMAL(5, 2) | DEFAULT 5.00 | Temperatura mínima aceptable (°C) |
-| `umbral_temp_max` | DECIMAL(5, 2) | DEFAULT 40.00 | Temperatura máxima aceptable (°C) |
-| `umbral_humedad_ambiente_min` | DECIMAL(5, 2) | DEFAULT 30.00 | Humedad ambiental mínima (%) |
-| `umbral_humedad_ambiente_max` | DECIMAL(5, 2) | DEFAULT 90.00 | Humedad ambiental máxima (%) |
-| `umbral_humedad_suelo_min` | DECIMAL(5, 2) | DEFAULT 30.00 | Humedad mínima del suelo (%) |
-| `umbral_co2_max` | DECIMAL(7, 2) | DEFAULT 1000.00 | CO2 máximo aceptable (ppm) |
 | `absorcion_co2_anual` | DECIMAL(8, 2) | NULL | Absorción CO2 estimada (kg/año) |
 
 **Índices**:
 - PRIMARY KEY en `id`
 - FOREIGN KEY `centro_id` REFERENCES `centro_educativo(id)` ON DELETE CASCADE
-- FOREIGN KEY `dispositivo_id` REFERENCES `dispositivo_esp32(id)` ON DELETE SET NULL
-- UNIQUE INDEX en `dispositivo_id`
 - INDEX en `centro_id`
 - INDEX en `especie`
 
@@ -434,21 +419,28 @@ classDiagram
 
 ### 4. Tabla: `dispositivo_esp32`
 
-**Descripción**: Dispositivos IoT (ESP32) que recopilan datos de los árboles.
+**Descripción**: Dispositivos IoT (ESP32) que monitorizan el ambiente del centro educativo.
 
 | Campo | Tipo | Restricciones | Descripción |
 |-------|------|---------------|-------------|
 | `id` | BIGSERIAL | PRIMARY KEY | Identificador único |
 | `mac_address` | VARCHAR(17) | NOT NULL, UNIQUE | Dirección MAC del ESP32 |
-| `arbol_id` | BIGINT | NULL, FOREIGN KEY | Árbol asociado |
+| `centro_id` | BIGINT | NOT NULL, FOREIGN KEY | Centro educativo al que pertenece |
 | `activo` | BOOLEAN | NOT NULL, DEFAULT TRUE | Dispositivo activo |
 | `ultima_conexion` | TIMESTAMPTZ | NULL | Última vez que envió datos |
 | `frecuencia_lectura_seg` | INTEGER | DEFAULT 30 | Intervalo de lecturas (segundos) |
+| `umbral_temp_min` | DECIMAL(5, 2) | DEFAULT 5.00 | Temperatura mínima aceptable (°C) |
+| `umbral_temp_max` | DECIMAL(5, 2) | DEFAULT 40.00 | Temperatura máxima aceptable (°C) |
+| `umbral_humedad_ambiente_min` | DECIMAL(5, 2) | DEFAULT 30.00 | Humedad ambiental mínima (%) |
+| `umbral_humedad_ambiente_max` | DECIMAL(5, 2) | DEFAULT 90.00 | Humedad ambiental máxima (%) |
+| `umbral_humedad_suelo_min` | DECIMAL(5, 2) | DEFAULT 30.00 | Humedad mínima del suelo (%) |
+| `umbral_co2_max` | DECIMAL(7, 2) | DEFAULT 1000.00 | CO2 máximo aceptable (ppm) |
 
 **Índices**:
 - PRIMARY KEY en `id`
 - UNIQUE INDEX en `mac_address`
-- FOREIGN KEY `arbol_id` REFERENCES `arbol(id)` ON DELETE SET NULL
+- FOREIGN KEY `centro_id` REFERENCES `centro_educativo(id)` ON DELETE CASCADE
+- INDEX en `centro_id`
 - INDEX en `activo`
 
 ---
@@ -461,8 +453,7 @@ classDiagram
 |-------|------|---------------|-------------|
 | `id` | BIGSERIAL | NOT NULL | Identificador |
 | `timestamp` | TIMESTAMPTZ | NOT NULL | Momento de la lectura |
-| `arbol_id` | BIGINT | NOT NULL, FOREIGN KEY | Árbol asociado |
-| `dispositivo_id` | BIGINT | NOT NULL, FOREIGN KEY | Dispositivo que envió |
+| `dispositivo_id` | BIGINT | NOT NULL, FOREIGN KEY | Dispositivo que envió la lectura |
 | `temperatura` | DECIMAL(5, 2) | NOT NULL | Temperatura ambiental (°C) |
 | `humedad_ambiente` | DECIMAL(5, 2) | NOT NULL | Humedad ambiental (%) |
 | `humedad_suelo` | DECIMAL(5, 2) | NOT NULL | Humedad del suelo (%) |
@@ -480,9 +471,7 @@ ya garantiza unicidad y la tabla existe creada por el script SQL (Hibernate no l
 
 **Índices**:
 - PRIMARY KEY en `(id, timestamp)`
-- FOREIGN KEY `arbol_id` REFERENCES `arbol(id)` ON DELETE CASCADE
 - FOREIGN KEY `dispositivo_id` REFERENCES `dispositivo_esp32(id)` ON DELETE CASCADE
-- INDEX en `arbol_id, timestamp DESC`
 - INDEX en `dispositivo_id, timestamp DESC`
 
 **Configuración TimescaleDB**:
@@ -499,7 +488,7 @@ SELECT create_hypertable('lectura', 'timestamp');
 | Campo | Tipo | Restricciones | Descripción |
 |-------|------|---------------|-------------|
 | `id` | BIGSERIAL | PRIMARY KEY | Identificador único |
-| `arbol_id` | BIGINT | NOT NULL, FOREIGN KEY | Árbol asociado |
+| `dispositivo_id` | BIGINT | NOT NULL, FOREIGN KEY | Dispositivo que generó la alerta |
 | `tipo_alerta` | VARCHAR(50) | NOT NULL, CHECK | Tipo de alerta |
 | `timestamp` | TIMESTAMPTZ | NOT NULL, DEFAULT NOW() | Momento de la alerta |
 | `mensaje` | TEXT | NOT NULL | Descripción de la alerta |
@@ -517,8 +506,8 @@ SELECT create_hypertable('lectura', 'timestamp');
 
 **Índices**:
 - PRIMARY KEY en `id`
-- FOREIGN KEY `arbol_id` REFERENCES `arbol(id)` ON DELETE CASCADE
-- INDEX en `arbol_id`
+- FOREIGN KEY `dispositivo_id` REFERENCES `dispositivo_esp32(id)` ON DELETE CASCADE
+- INDEX en `dispositivo_id`
 - INDEX en `estado`
 - INDEX en `timestamp DESC`
 
@@ -630,14 +619,22 @@ CREATE INDEX idx_centro_educativo_nombre ON centro_educativo(nombre);
 CREATE TABLE dispositivo_esp32 (
     id BIGSERIAL,
     mac_address VARCHAR(17) NOT NULL,
-    arbol_id BIGINT,
+    centro_id BIGINT NOT NULL,
     activo BOOLEAN NOT NULL DEFAULT TRUE,
     ultima_conexion TIMESTAMPTZ,
     frecuencia_lectura_seg INTEGER DEFAULT 30,
+    umbral_temp_min             DECIMAL(5,2) DEFAULT 5.00,
+    umbral_temp_max             DECIMAL(5,2) DEFAULT 40.00,
+    umbral_humedad_ambiente_min DECIMAL(5,2) DEFAULT 30.00,
+    umbral_humedad_ambiente_max DECIMAL(5,2) DEFAULT 90.00,
+    umbral_humedad_suelo_min    DECIMAL(5,2) DEFAULT 30.00,
+    umbral_co2_max              DECIMAL(7,2) DEFAULT 1000.00,
     CONSTRAINT pk_dispositivo_esp32 PRIMARY KEY (id),
-    CONSTRAINT uq_dispositivo_mac_address UNIQUE (mac_address)
+    CONSTRAINT uq_dispositivo_mac_address UNIQUE (mac_address),
+    CONSTRAINT fk_dispositivo_centro FOREIGN KEY (centro_id) REFERENCES centro_educativo(id) ON DELETE CASCADE
 );
 
+CREATE INDEX idx_dispositivo_centro ON dispositivo_esp32(centro_id);
 CREATE INDEX idx_dispositivo_activo ON dispositivo_esp32(activo);
 
 -- ============================================
@@ -650,31 +647,14 @@ CREATE TABLE arbol (
     especie VARCHAR(150) NOT NULL,
     fecha_plantacion DATE NOT NULL,
     ubicacion_especifica VARCHAR(200),
-    dispositivo_id BIGINT,
-    -- Umbrales de temperatura
-    umbral_temp_min DECIMAL(5, 2) DEFAULT 5.00,
-    umbral_temp_max DECIMAL(5, 2) DEFAULT 40.00,
-    -- Umbrales de humedad ambiental
-    umbral_humedad_ambiente_min DECIMAL(5, 2) DEFAULT 30.00,
-    umbral_humedad_ambiente_max DECIMAL(5, 2) DEFAULT 90.00,
-    -- Umbrales de humedad del suelo
-    umbral_humedad_suelo_min DECIMAL(5, 2) DEFAULT 30.00,
-    -- Umbrales de CO2 (opcional, solo si tiene sensor)
-    umbral_co2_max DECIMAL(7, 2) DEFAULT 1000.00,
     -- Absorción de CO2 estimada al año (kg CO2/año)
     absorcion_co2_anual DECIMAL(8, 2),
     CONSTRAINT pk_arbol PRIMARY KEY (id),
-    CONSTRAINT fk_arbol_centro FOREIGN KEY (centro_id) REFERENCES centro_educativo(id) ON DELETE CASCADE,
-    CONSTRAINT fk_arbol_dispositivo FOREIGN KEY (dispositivo_id) REFERENCES dispositivo_esp32(id) ON DELETE SET NULL,
-    CONSTRAINT uq_arbol_dispositivo UNIQUE (dispositivo_id)
+    CONSTRAINT fk_arbol_centro FOREIGN KEY (centro_id) REFERENCES centro_educativo(id) ON DELETE CASCADE
 );
 
 CREATE INDEX idx_arbol_centro ON arbol(centro_id);
 CREATE INDEX idx_arbol_especie ON arbol(especie);
-
--- Actualizar foreign key en dispositivo_esp32
-ALTER TABLE dispositivo_esp32
-ADD CONSTRAINT fk_dispositivo_arbol FOREIGN KEY (arbol_id) REFERENCES arbol(id) ON DELETE SET NULL;
 
 -- ============================================
 -- 5. TABLA: lectura (HYPERTABLE)
@@ -682,7 +662,6 @@ ADD CONSTRAINT fk_dispositivo_arbol FOREIGN KEY (arbol_id) REFERENCES arbol(id) 
 CREATE TABLE lectura (
     id BIGSERIAL NOT NULL,
     timestamp TIMESTAMPTZ NOT NULL,
-    arbol_id BIGINT NOT NULL,
     dispositivo_id BIGINT NOT NULL,
     -- Sensores obligatorios (configuración básica)
     temperatura DECIMAL(5, 2) NOT NULL,
@@ -693,7 +672,6 @@ CREATE TABLE lectura (
     luz1 DECIMAL(5, 2),                         -- NULL si no tiene sensor LDR 1
     luz2 DECIMAL(5, 2),                         -- NULL si no tiene sensor LDR 2
     CONSTRAINT pk_lectura PRIMARY KEY (id, timestamp),
-    CONSTRAINT fk_lectura_arbol FOREIGN KEY (arbol_id) REFERENCES arbol(id) ON DELETE CASCADE,
     CONSTRAINT fk_lectura_dispositivo FOREIGN KEY (dispositivo_id) REFERENCES dispositivo_esp32(id) ON DELETE CASCADE,
     -- Validaciones de rangos razonables
     CONSTRAINT chk_temperatura CHECK (temperatura BETWEEN -50.00 AND 80.00),
@@ -707,7 +685,6 @@ CREATE TABLE lectura (
 -- Convertir a hypertable (TimescaleDB)
 SELECT create_hypertable('lectura', 'timestamp');
 
-CREATE INDEX idx_lectura_arbol_timestamp ON lectura(arbol_id, timestamp DESC);
 CREATE INDEX idx_lectura_dispositivo_timestamp ON lectura(dispositivo_id, timestamp DESC);
 
 -- ============================================
@@ -715,14 +692,14 @@ CREATE INDEX idx_lectura_dispositivo_timestamp ON lectura(dispositivo_id, timest
 -- ============================================
 CREATE TABLE alerta (
     id BIGSERIAL,
-    arbol_id BIGINT NOT NULL,
+    dispositivo_id BIGINT NOT NULL,
     tipo_alerta VARCHAR(50) NOT NULL,
     timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     mensaje TEXT NOT NULL,
     estado VARCHAR(20) NOT NULL DEFAULT 'ACTIVA',
     fecha_resolucion TIMESTAMPTZ,
     CONSTRAINT pk_alerta PRIMARY KEY (id),
-    CONSTRAINT fk_alerta_arbol FOREIGN KEY (arbol_id) REFERENCES arbol(id) ON DELETE CASCADE,
+    CONSTRAINT fk_alerta_dispositivo FOREIGN KEY (dispositivo_id) REFERENCES dispositivo_esp32(id) ON DELETE CASCADE,
     CONSTRAINT chk_alerta_tipo CHECK (tipo_alerta IN (
         'TEMPERATURA_ALTA',
         'TEMPERATURA_BAJA',
@@ -735,7 +712,7 @@ CREATE TABLE alerta (
     CONSTRAINT chk_alerta_estado CHECK (estado IN ('ACTIVA', 'RESUELTA', 'IGNORADA'))
 );
 
-CREATE INDEX idx_alerta_arbol ON alerta(arbol_id);
+CREATE INDEX idx_alerta_dispositivo ON alerta(dispositivo_id);
 CREATE INDEX idx_alerta_estado ON alerta(estado);
 CREATE INDEX idx_alerta_timestamp ON alerta(timestamp DESC);
 
@@ -832,7 +809,7 @@ Además de las restricciones de base de datos, las entidades JPA incluirán:
 
 **Repositorio**: [github.com/riordi80/vocational-training-final-project](https://github.com/riordi80/vocational-training-final-project)
 
-**Última actualización**: 2026-02-15
+**Última actualización**: 2026-04-11
 
 ### Colaboradores
 

--- a/docs/05. ROADMAP_IOT_ESP32.md
+++ b/docs/05. ROADMAP_IOT_ESP32.md
@@ -21,7 +21,7 @@ sequenceDiagram
     ESP32->>Backend: HTTP POST /api/lecturas
     Note over ESP32,Backend: JSON con macAddress + datos sensores
     Backend->>Backend: Buscar dispositivo por MAC
-    Backend->>Backend: Obtener arbol_id asociado
+    Backend->>Backend: Verificar que el dispositivo tiene centro_id asignado
     Backend->>DB: INSERT en tabla lectura (hypertable)
     Backend-->>ESP32: 201 Created / 4xx Error
     ESP32->>ESP32: Esperar frecuencia_lectura_seg
@@ -33,7 +33,7 @@ El ESP32 se identifica ante el backend mediante su **MAC address** (ya modelada 
 
 1. ESP32 obtiene su MAC automáticamente con `WiFi.macAddress()`
 2. Envía la MAC en el JSON del POST
-3. El backend busca el dispositivo por MAC → obtiene `dispositivo_id` y `arbol_id`
+3. El backend busca el dispositivo por MAC → obtiene `dispositivo_id` y `centro_id`
 4. Si la MAC no existe en BD → responde 404 (dispositivo no registrado)
 
 ### 1.3 Formato del JSON (ESP32 → Backend)
@@ -63,7 +63,7 @@ El ESP32 se identifica ante el backend mediante su **MAC address** (ya modelada 
 | `201 Created` | Lectura almacenada correctamente |
 | `400 Bad Request` | JSON inválido o valores fuera de rango |
 | `404 Not Found` | MAC address no registrada en el sistema |
-| `422 Unprocessable Entity` | Dispositivo existe pero no tiene árbol asignado |
+| `422 Unprocessable Entity` | Dispositivo existe pero no tiene centro asignado |
 
 ---
 
@@ -93,9 +93,9 @@ El ESP32 se identifica ante el backend mediante su **MAC address** (ya modelada 
 
 El ESP32 solo envía su MAC address. El backend se encarga de:
 - Buscar el `DispositivoEsp32` por MAC
-- Obtener el `Arbol` asociado
+- Verificar que tiene `centro_id` asignado
 - Actualizar `ultimaConexion` del dispositivo
-- Insertar la `Lectura` con las FK correctas
+- Insertar la `Lectura` con la FK de dispositivo
 
 **Razón**: Simplifica el firmware del ESP32 y centraliza la lógica.
 
@@ -141,14 +141,14 @@ en PKs compuestas (`@IdClass`), por lo que `timestamp` es un campo regular en JP
 **Lógica del endpoint `POST /api/lecturas`**:
 1. Recibir `LecturaRequest` (JSON del ESP32)
 2. Buscar `DispositivoEsp32` por `macAddress`
-3. Verificar que el dispositivo tiene un `Arbol` asignado
-4. Crear entidad `Lectura` con timestamp actual + datos + FK
+3. Verificar que el dispositivo tiene `centro_id` asignado
+4. Crear entidad `Lectura` con timestamp actual + datos + FK de dispositivo
 5. Actualizar `ultimaConexion` del dispositivo
 6. Guardar y devolver 201
 
 **Referencia SQL** (tabla `lectura` en `create_database.sql:98-125`):
 - PK compuesta: `(id, timestamp)` - hypertable TimescaleDB
-- FK: `arbol_id` → arbol, `dispositivo_id` → dispositivo_esp32
+- FK: `dispositivo_id` → dispositivo_esp32
 - Validaciones: temperatura [-50, 80], humedades [0, 100], co2 [0, 10000]
 
 ---
@@ -194,7 +194,7 @@ loop():
 ### Paso 3 - Validación del flujo completo
 
 - [x] Registrar un `DispositivoEsp32` en BD con la MAC real del ESP32
-- [x] Crear un `Arbol` de prueba asociado al dispositivo
+- [x] Verificar que el dispositivo tiene `centro_id` asignado en BD
 - [x] Compilar y subir sketch al ESP32
 - [x] Verificar en Serial Monitor: conexión WiFi + envío HTTP
 - [x] Verificar en BD: `SELECT * FROM lectura ORDER BY timestamp DESC LIMIT 5;`
@@ -230,7 +230,7 @@ loop():
 |---------|---------------------|
 | `backend/create_database.sql` (líneas 96-125) | Esquema tabla `lectura` (hypertable) |
 | `backend/src/.../model/DispositivoEsp32.java` | Entidad dispositivo con MAC address |
-| `backend/src/.../model/Arbol.java` | Entidad árbol con umbrales de alerta |
+| `backend/src/.../model/DispositivoEsp32.java` | Entidad dispositivo con umbrales de alerta y centro asociado |
 | `docs/04. MODELO_DATOS.md` | Modelo completo con relaciones |
 | `docs/03. ESPECIFICACION_TECNICA.md` (sección 2.6) | Especificación IoT planificada |
 | `esp32/sketch_feb11a/sketch_feb11a.ino` | Sketch actual (SHT40 + humedad suelo + MH-Z19D CO2 + LDR 1/2) |

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -42,19 +42,23 @@ frontend/
 │   │   │   └── ComponentLibrary.jsx
 │   │   ├── arboles/
 │   │   │   ├── ListadoArboles.jsx
-│   │   │   ├── DetalleArbol.jsx      # Incluye sección "Última Lectura" con umbrales
+│   │   │   ├── DetalleArbol.jsx      # Info general y absorción CO2; sin sección IoT
 │   │   │   ├── FormularioArbol.jsx
-│   │   │   └── HistoricoArbol.jsx    # Gráfica Recharts + tabla paginada de lecturas IoT
+│   │   │   └── HistoricoArbol.jsx    # (legacy) Historial por árbol
+│   │   ├── dispositivos/
+│   │   │   ├── FormularioDispositivo.jsx  # Crear/editar dispositivo (MAC, centro, frecuencia, umbrales)
+│   │   │   └── HistoricoDispositivo.jsx   # Gráfica Recharts + tabla paginada por dispositivoId
 │   │   ├── centros/
 │   │   ├── usuarios/        # Gestión de usuarios (solo ADMIN)
 │   │   └── ...
 │   ├── services/            # Llamadas a API
 │   │   ├── api.js           # Configuración axios
-│   │   ├── arbolesService.js # CRUD completo de árboles
-│   │   ├── centrosService.js # CRUD completo de centros
-│   │   ├── usuariosService.js # CRUD de usuarios (solo ADMIN)
-│   │   ├── usuarioCentroService.js # Asignación usuario-centro
-│   │   ├── lecturasService.js # Lecturas IoT (tabla, gráfica stride sampling, última lectura)
+│   │   ├── arbolesService.js
+│   │   ├── centrosService.js
+│   │   ├── usuariosService.js
+│   │   ├── usuarioCentroService.js
+│   │   ├── dispositivosService.js  # CRUD dispositivos ESP32
+│   │   ├── lecturasService.js      # Lecturas IoT (endpoints /dispositivo/)
 │   │   └── ...
 │   ├── context/             # Context API para estado global
 │   │   ├── AuthContext.jsx
@@ -155,30 +159,36 @@ npm run lint             # Ejecuta ESLint para verificar código
 - Integración con arbolesService y centrosService
 
 ### 5. Detalle de Árbol (`/arboles/:id`)
-- Vista completa con información general y umbrales de monitorización
+- Vista con información general y absorción CO2 anual
 - Botones: Volver, Editar, Eliminar
 - Modal de confirmación antes de eliminar
-- Manejo de estados (loading, error, árbol no encontrado)
-- Formateo de fechas mejorado
-- Integración con getArbolById y deleteArbol
-- Navegación con state para feedback
+- Sin sección IoT (lecturas e histórico se acceden desde el dispositivo)
 
 ### 6. Formulario Árbol (`/arboles/nuevo` y `/arboles/:id/editar`)
-- Componente dual: crear Y editar en uno solo
-- Campos obligatorios: nombre, especie, fecha plantación, centro educativo
-- Campos opcionales: ubicación, umbrales de monitorización
-- Validaciones client-side completas (campos requeridos, fecha no futura, rangos de umbrales)
-- Carga de centros desde API para select
-- Detección automática de modo (crear/editar) con useParams
-- Navegación con state para mensajes de éxito
-- Integración con createArbol y updateArbol
+- Campos: nombre, especie, fecha plantación, centro educativo, ubicación, absorción CO2
+- Validaciones client-side (campos requeridos, fecha no futura)
+- Sin umbrales de monitorización (se configuran en el dispositivo)
 
-### 7. Histórico de Lecturas (`/arboles/:id/lecturas`)
-- Selector de período predefinido: Hoy / 7 días / 30 días / 6 meses / 1 año
-- Gráfica de series temporales con Recharts (stride sampling, máx. 400 puntos reales del rango)
-- Tabla de lecturas paginada server-side
-- Datos representados: temperatura, humedad ambiente, humedad suelo, CO2, diámetro de tronco
-- Integración con `lecturasService.js` (`getGraficaArbol`, `getLecturasArbol`, `getUltimaLectura`)
+### 7. Histórico de Lecturas por Dispositivo (`/dispositivos/:id/lecturas`)
+- Selector de período: Hoy / 7 días / 30 días / 6 meses / 1 año
+- Gráfica 1: temperatura, humedad ambiente, humedad suelo, luz1, luz2 (Recharts)
+- Gráfica 2: CO2 en ppm (escala separada)
+- Tabla de lecturas paginada server-side (stride sampling, máx. 400 puntos reales)
+- Polling automático según frecuenciaLecturaSeg del dispositivo
+- Muestra MAC address y centro del dispositivo en la cabecera
+
+### 8. Formulario Dispositivo (`/dispositivos/nuevo` y `/dispositivos/:id/editar`)
+- Campos obligatorios: MAC address (formato XX:XX:XX:XX:XX:XX), centro educativo
+- Campos: frecuencia de lectura (seg), activo
+- Sección de umbrales de monitorización: temp min/max, humedad amb min/max, humedad suelo min, CO2 max
+- Validación de formato MAC
+- Accesible desde DetalleCentro (botón "Añadir Dispositivo" / "Editar")
+
+### 9. Detalle Centro (`/centros/:id`)
+- Información general + mapa Leaflet
+- Tabla de árboles del centro
+- **Nueva sección**: Tabla de dispositivos ESP32 con MAC, estado (activo/inactivo), frecuencia, última conexión
+- Acciones por dispositivo: Ver Histórico, Editar, Eliminar (con modal confirmación)
 
 ## Requisitos Funcionales Adicionales
 
@@ -266,9 +276,9 @@ Todos los formularios incluyen validación client-side:
 
 - Email válido
 - Campos requeridos
-- Rangos numéricos (umbrales)
 - Fechas coherentes
 - Confirmación de contraseña
+- Rangos numéricos (umbrales) — en FormularioDispositivo
 
 ## Estilos y Componentes
 
@@ -435,8 +445,14 @@ Este proyecto usa:
 - [x] Sistema de roles y permisos (ADMIN, COORDINADOR, acceso público)
 - [x] CRUD completo de árboles:
   - ListadoArboles (listar, filtrar, buscar)
-  - DetalleArbol (ver detalles completos)
+  - DetalleArbol (info general y CO2; sin sección IoT)
   - FormularioArbol (crear y editar)
+- [x] CRUD completo de dispositivos ESP32:
+  - FormularioDispositivo (crear y editar, con umbrales)
+  - HistoricoDispositivo (gráficas + tabla paginada por dispositivoId)
+- [x] Lecturas IoT asociadas a dispositivo (no a árbol): endpoints /dispositivo/
+- [x] DetalleCentro muestra dispositivos del centro con acciones
+- [x] Umbrales de monitorización configurables por dispositivo
 - [x] Gestión de usuarios (solo ADMIN):
   - ListadoUsuarios, DetalleUsuario, FormularioUsuario
   - Asignación/desasignación de coordinadores a centros
@@ -469,7 +485,7 @@ Este proyecto usa:
 
 **Repositorio**: [github.com/riordi80/vocational-training-final-project](https://github.com/riordi80/vocational-training-final-project)
 
-**Última actualización**: 2026-02-19
+**Última actualización**: 2026-04-11
 
 ### Colaboradores
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,6 +16,8 @@ import DetalleUsuario from './pages/usuarios/DetalleUsuario';
 import FormularioUsuario from './pages/usuarios/FormularioUsuario';
 import AccessDenied from './pages/access-denied/AccessDenied';
 import HistoricoArbol from './pages/arboles/HistoricoArbol';
+import HistoricoDispositivo from './pages/dispositivos/HistoricoDispositivo';
+import FormularioDispositivo from './pages/dispositivos/FormularioDispositivo';
 import './App.css';
 
 function App() {
@@ -38,6 +40,7 @@ function App() {
           <Route path="/arboles" element={<ListadoArboles />} />
           <Route path="/arboles/:id" element={<DetalleArbol />} />
           <Route path="/arboles/:id/lecturas" element={<HistoricoArbol />} />
+          <Route path="/dispositivos/:id/lecturas" element={<HistoricoDispositivo />} />
           <Route path="/centros" element={<ListadoCentros />} />
           <Route path="/centros/:id" element={<DetalleCentro />} />
           <Route path="/access-denied" element={<AccessDenied />} />
@@ -51,6 +54,16 @@ function App() {
           <Route path="/arboles/:id/editar" element={
             <ProtectedRoute requiredRoles={['ADMIN', 'COORDINADOR']}>
               <FormularioArbol />
+            </ProtectedRoute>
+          } />
+          <Route path="/dispositivos/nuevo" element={
+            <ProtectedRoute requiredRoles={['ADMIN', 'COORDINADOR']}>
+              <FormularioDispositivo />
+            </ProtectedRoute>
+          } />
+          <Route path="/dispositivos/:id/editar" element={
+            <ProtectedRoute requiredRoles={['ADMIN', 'COORDINADOR']}>
+              <FormularioDispositivo />
             </ProtectedRoute>
           } />
           <Route path="/centros/nuevo" element={

--- a/frontend/src/layout/Footer.jsx
+++ b/frontend/src/layout/Footer.jsx
@@ -53,7 +53,7 @@ const Footer = () => {
 
             {/* Barra de copyright */}
             <div className="bg-brand-primary border-t border-white/20 px-10 py-2 flex flex-wrap items-center gap-3">
-                <p className="text-xs text-white/70">© 2025 – Fundación Sergio Alonso</p>
+                <p className="text-xs text-white/70">© 2026 – Fundación Sergio Alonso</p>
                 <span className="text-white/30">|</span>
                 <a href="#" className="text-xs text-white/70 hover:text-brand-accent transition">Aviso Legal</a>
                 <span className="text-white/30">|</span>

--- a/frontend/src/pages/arboles/DetalleArbol.jsx
+++ b/frontend/src/pages/arboles/DetalleArbol.jsx
@@ -1,7 +1,6 @@
   import { useState, useEffect } from 'react';
   import { useParams, useNavigate } from 'react-router-dom';
   import { getArbolById, deleteArbol } from '../../services/arbolesService';
-  import { getUltimaLectura } from '../../services/lecturasService';
   import Button from '../../components/common/Button';
   import Spinner from '../../components/common/Spinner';
   import Alert from '../../components/common/Alert';
@@ -16,8 +15,6 @@
     const [error, setError] = useState('');
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
     const [deleting, setDeleting] = useState(false);
-    const [ultimaLectura, setUltimaLectura] = useState(null);
-    const [loadingLectura, setLoadingLectura] = useState(false);
     const { canEditArbol, canDeleteArbol } = usePermissions();
 
     useEffect(() => {
@@ -35,17 +32,6 @@
         setError('No se pudo conectar con el servidor. Si es la primera carga, puede estar iniciándose (30-60 seg). Recarga la página en unos momentos.');
       } finally {
         setLoading(false);
-      }
-      // Cargamos la última lectura en paralelo (sin bloquear la carga principal)
-      try {
-        setLoadingLectura(true);
-        const lectura = await getUltimaLectura(id);
-        setUltimaLectura(lectura);
-      } catch {
-        // La sección de lecturas simplemente no se muestra si falla
-        setUltimaLectura(null);
-      } finally {
-        setLoadingLectura(false);
       }
     };
 
@@ -80,33 +66,6 @@
         month: 'long',
         day: 'numeric'
       });
-    };
-
-    const formatearTimestamp = (ts) => {
-      if (!ts) return '-';
-      return new Date(ts).toLocaleString('es-ES', {
-        day: '2-digit', month: '2-digit', year: 'numeric',
-        hour: '2-digit', minute: '2-digit',
-      });
-    };
-
-    const tiempoRelativo = (ts) => {
-      if (!ts) return null;
-      const diffMs = Date.now() - new Date(ts).getTime();
-      const diffMin = Math.round(diffMs / 60000);
-      if (diffMin < 1) return 'hace menos de 1 min';
-      if (diffMin < 60) return `hace ${diffMin} min`;
-      const diffH = Math.round(diffMin / 60);
-      if (diffH < 24) return `hace ${diffH} h`;
-      return formatearTimestamp(ts);
-    };
-
-    const fueraDeRango = (valor, min, max) => {
-      if (valor == null) return false;
-      const v = parseFloat(valor);
-      if (min != null && v < parseFloat(min)) return true;
-      if (max != null && v > parseFloat(max)) return true;
-      return false;
     };
 
     if (loading) {
@@ -181,102 +140,11 @@
           </div>
         </div>
 
-        {/* Card unificada: Última Lectura → Info General → Umbrales */}
+        {/* Card unificada: Info General → Umbrales */}
         <div className="bg-white rounded-lg shadow-md overflow-hidden">
 
-          {/* ── Última Lectura ── */}
-          <div className="p-6">
-            <div className="flex items-center justify-between mb-4">
-              <div>
-                <h2 className="text-xl font-semibold text-gray-800">Última Lectura</h2>
-                <p className="text-sm text-gray-500 mt-0.5">
-                  {loadingLectura
-                    ? 'Cargando...'
-                    : ultimaLectura
-                      ? tiempoRelativo(ultimaLectura.timestamp)
-                      : 'Sin lecturas registradas aún'}
-                </p>
-              </div>
-              <Button variant="outline" onClick={() => navigate(`/arboles/${id}/lecturas`)}>
-                Ver histórico →
-              </Button>
-            </div>
-
-            {loadingLectura ? (
-              <div className="flex items-center gap-2 text-gray-400 text-sm py-2">
-                <Spinner size="sm" />
-              </div>
-            ) : ultimaLectura ? (
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
-                {/* Temperatura */}
-                {(() => {
-                  const alerta = fueraDeRango(ultimaLectura.temperatura, arbol.umbralTempMin, arbol.umbralTempMax);
-                  return (
-                    <div>
-                      <label className="block text-sm font-medium text-gray-600 mb-1">
-                        Temperatura
-                      </label>
-                      <p className={`text-lg font-semibold ${alerta ? 'text-red-600' : 'text-gray-900'}`}>
-                        {ultimaLectura.temperatura != null
-                          ? `${parseFloat(ultimaLectura.temperatura).toFixed(1)} °C`
-                          : '-'}
-                      </p>
-                      {alerta && (
-                        <span className="text-xs text-red-500 mt-0.5 block">Fuera de umbral</span>
-                      )}
-                    </div>
-                  );
-                })()}
-
-                {/* Humedad Ambiente */}
-                {(() => {
-                  const alerta = fueraDeRango(ultimaLectura.humedadAmbiente, arbol.umbralHumedadAmbienteMin, arbol.umbralHumedadAmbienteMax);
-                  return (
-                    <div>
-                      <label className="block text-sm font-medium text-gray-600 mb-1">
-                        Humedad Ambiente
-                      </label>
-                      <p className={`text-lg font-semibold ${alerta ? 'text-red-600' : 'text-gray-900'}`}>
-                        {ultimaLectura.humedadAmbiente != null
-                          ? `${parseFloat(ultimaLectura.humedadAmbiente).toFixed(1)} %`
-                          : '-'}
-                      </p>
-                      {alerta && (
-                        <span className="text-xs text-red-500 mt-0.5 block">Fuera de umbral</span>
-                      )}
-                    </div>
-                  );
-                })()}
-
-                {/* Humedad Suelo */}
-                <div>
-                  <label className="block text-sm font-medium text-gray-600 mb-1">
-                    Humedad Suelo
-                  </label>
-                  <p className="text-lg font-semibold text-gray-900">
-                    {ultimaLectura.humedadSuelo != null
-                      ? `${parseFloat(ultimaLectura.humedadSuelo).toFixed(1)} %`
-                      : '-'}
-                  </p>
-                </div>
-
-                {/* CO2 */}
-                <div>
-                  <label className="block text-sm font-medium text-gray-600 mb-1">
-                    CO2
-                  </label>
-                  <p className="text-lg font-semibold text-gray-900">
-                    {ultimaLectura.co2 != null
-                      ? `${parseFloat(ultimaLectura.co2).toFixed(0)} ppm`
-                      : '-'}
-                  </p>
-                </div>
-              </div>
-            ) : null}
-          </div>
-
           {/* ── Información General ── */}
-          <div className="border-t border-gray-200 p-6 bg-gray-50">
+          <div className="p-6 bg-gray-50">
             <h2 className="text-xl font-semibold text-gray-800 mb-4">Información General</h2>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -316,54 +184,6 @@
             </div>
           </div>
 
-          {/* ── Umbrales de Monitorización ── */}
-          <div className="border-t border-gray-200 p-6">
-            <h2 className="text-xl font-semibold text-gray-800 mb-4">Umbrales de Monitorización</h2>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              <div>
-                <label className="block text-sm font-medium text-gray-600 mb-1">Temperatura Mínima</label>
-                <p className="text-gray-900">
-                  {arbol.umbralTempMin !== null ? `${arbol.umbralTempMin} °C` : 'No configurado'}
-                </p>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-600 mb-1">Temperatura Máxima</label>
-                <p className="text-gray-900">
-                  {arbol.umbralTempMax !== null ? `${arbol.umbralTempMax} °C` : 'No configurado'}
-                </p>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-600 mb-1">Humedad Ambiente Mínima</label>
-                <p className="text-gray-900">
-                  {arbol.umbralHumedadAmbienteMin !== null ? `${arbol.umbralHumedadAmbienteMin} %` : 'No configurado'}
-                </p>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-600 mb-1">Humedad Ambiente Máxima</label>
-                <p className="text-gray-900">
-                  {arbol.umbralHumedadAmbienteMax !== null ? `${arbol.umbralHumedadAmbienteMax} %` : 'No configurado'}
-                </p>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-600 mb-1">Humedad Suelo Mínima</label>
-                <p className="text-gray-900">
-                  {arbol.umbralHumedadSueloMin !== null ? `${arbol.umbralHumedadSueloMin} %` : 'No configurado'}
-                </p>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-600 mb-1">CO2 Máximo</label>
-                <p className="text-gray-900">
-                  {arbol.umbralCO2Max !== null ? `${arbol.umbralCO2Max} ppm` : 'No configurado'}
-                </p>
-              </div>
-            </div>
-          </div>
         </div>
 
         {/* Modal de confirmación de eliminación */}

--- a/frontend/src/pages/arboles/FormularioArbol.jsx
+++ b/frontend/src/pages/arboles/FormularioArbol.jsx
@@ -23,12 +23,6 @@
       fechaPlantacion: '',
       ubicacionEspecifica: '',
       centroEducativo: { id: centroIdDesdeState || '' },
-      umbralTempMin: '',
-      umbralTempMax: '',
-      umbralHumedadAmbienteMin: '',
-      umbralHumedadAmbienteMax: '',
-      umbralHumedadSueloMin: '',
-      umbralCO2Max: '',
       absorcionCo2Anual: ''
     });
 
@@ -70,12 +64,6 @@
             fechaPlantacion: fechaFormateada,
             ubicacionEspecifica: arbolData.ubicacionEspecifica || '',
             centroEducativo: { id: arbolData.centroEducativo?.id || '' },
-            umbralTempMin: arbolData.umbralTempMin || '',
-            umbralTempMax: arbolData.umbralTempMax || '',
-            umbralHumedadAmbienteMin: arbolData.umbralHumedadAmbienteMin || '',
-            umbralHumedadAmbienteMax: arbolData.umbralHumedadAmbienteMax || '',
-            umbralHumedadSueloMin: arbolData.umbralHumedadSueloMin || '',
-            umbralCO2Max: arbolData.umbralCO2Max || '',
             absorcionCo2Anual: arbolData.absorcionCo2Anual || ''
           });
         }
@@ -141,24 +129,6 @@
       }
 
       // Validaciones de umbrales (si están presentes)
-      if (formData.umbralTempMin !== '' && formData.umbralTempMax !== '') {
-        const tempMin = parseFloat(formData.umbralTempMin);
-        const tempMax = parseFloat(formData.umbralTempMax);
-
-        if (tempMin >= tempMax) {
-          nuevosErrores.umbralTempMin = 'La temperatura mínima debe ser menor que la máxima';
-        }
-      }
-
-      if (formData.umbralHumedadAmbienteMin !== '' && formData.umbralHumedadAmbienteMax !== '') {
-        const humMin = parseFloat(formData.umbralHumedadAmbienteMin);
-        const humMax = parseFloat(formData.umbralHumedadAmbienteMax);
-
-        if (humMin >= humMax) {
-          nuevosErrores.umbralHumedadAmbienteMin = 'La humedad mínima debe ser menor que la máxima';
-        }
-      }
-
       setErrors(nuevosErrores);
       return Object.keys(nuevosErrores).length === 0;
     };
@@ -182,12 +152,6 @@
           fechaPlantacion: formData.fechaPlantacion,
           ubicacionEspecifica: formData.ubicacionEspecifica.trim() || null,
           centroEducativo: { id: parseInt(formData.centroEducativo.id) },
-          umbralTempMin: formData.umbralTempMin !== '' ? parseFloat(formData.umbralTempMin) : null,
-          umbralTempMax: formData.umbralTempMax !== '' ? parseFloat(formData.umbralTempMax) : null,
-          umbralHumedadAmbienteMin: formData.umbralHumedadAmbienteMin !== '' ? parseFloat(formData.umbralHumedadAmbienteMin) : null,
-          umbralHumedadAmbienteMax: formData.umbralHumedadAmbienteMax !== '' ? parseFloat(formData.umbralHumedadAmbienteMax) : null,
-          umbralHumedadSueloMin: formData.umbralHumedadSueloMin !== '' ? parseFloat(formData.umbralHumedadSueloMin) : null,
-          umbralCO2Max: formData.umbralCO2Max !== '' ? parseFloat(formData.umbralCO2Max) : null,
           absorcionCo2Anual: formData.absorcionCo2Anual !== '' ? parseFloat(formData.absorcionCo2Anual) : null
         };
 
@@ -351,89 +315,6 @@
                     Estimación de kg de CO2 absorbidos al año
                   </p>
                 </div>
-              </div>
-            </div>
-
-            {/* Sección: Umbrales de Monitorización */}
-            <div className="mb-6 pt-6 border-t border-gray-200">
-              <h2 className="text-xl font-semibold text-gray-800 mb-4">
-                Umbrales de Monitorización (Opcional)
-              </h2>
-
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {/* Temperatura Mínima */}
-                <Input
-                  id="umbralTempMin"
-                  name="umbralTempMin"
-                  label="Temperatura Mínima (°C)"
-                  type="number"
-                  step="0.1"
-                  value={formData.umbralTempMin}
-                  onChange={handleChange}
-                  error={errors.umbralTempMin}
-                  placeholder="Ej: 10"
-                />
-
-                {/* Temperatura Máxima */}
-                <Input
-                  id="umbralTempMax"
-                  name="umbralTempMax"
-                  label="Temperatura Máxima (°C)"
-                  type="number"
-                  step="0.1"
-                  value={formData.umbralTempMax}
-                  onChange={handleChange}
-                  placeholder="Ej: 35"
-                />
-
-                {/* Humedad Ambiente Mínima */}
-                <Input
-                  id="umbralHumedadAmbienteMin"
-                  name="umbralHumedadAmbienteMin"
-                  label="Humedad Ambiente Mínima (%)"
-                  type="number"
-                  step="0.1"
-                  value={formData.umbralHumedadAmbienteMin}
-                  onChange={handleChange}
-                  error={errors.umbralHumedadAmbienteMin}
-                  placeholder="Ej: 30"
-                />
-
-                {/* Humedad Ambiente Máxima */}
-                <Input
-                  id="umbralHumedadAmbienteMax"
-                  name="umbralHumedadAmbienteMax"
-                  label="Humedad Ambiente Máxima (%)"
-                  type="number"
-                  step="0.1"
-                  value={formData.umbralHumedadAmbienteMax}
-                  onChange={handleChange}
-                  placeholder="Ej: 90"
-                />
-
-                {/* Humedad Suelo Mínima */}
-                <Input
-                  id="umbralHumedadSueloMin"
-                  name="umbralHumedadSueloMin"
-                  label="Humedad Suelo Mínima (%)"
-                  type="number"
-                  step="0.1"
-                  value={formData.umbralHumedadSueloMin}
-                  onChange={handleChange}
-                  placeholder="Ej: 20"
-                />
-
-                {/* CO2 Máximo */}
-                <Input
-                  id="umbralCO2Max"
-                  name="umbralCO2Max"
-                  label="CO2 Máximo (ppm)"
-                  type="number"
-                  step="0.01"
-                  value={formData.umbralCO2Max}
-                  onChange={handleChange}
-                  placeholder="Ej: 1000"
-                />
               </div>
             </div>
 

--- a/frontend/src/pages/centros/DetalleCentro.jsx
+++ b/frontend/src/pages/centros/DetalleCentro.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Plus } from 'lucide-react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { getCentroById, deleteCentro, getArbolesByCentro } from '../../services/centrosService';
+import { getDispositivosByCentro, deleteDispositivo } from '../../services/dispositivosService';
 import Button from '../../components/common/Button';
 import Spinner from '../../components/common/Spinner';
 import Alert from '../../components/common/Alert';
@@ -26,15 +27,19 @@ function DetalleCentro() {
 
   const [centro, setCentro] = useState(null);
   const [arboles, setArboles] = useState([]);
+  const [dispositivos, setDispositivos] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showDeleteDispositivoModal, setShowDeleteDispositivoModal] = useState(false);
+  const [dispositivoAEliminar, setDispositivoAEliminar] = useState(null);
   const { isAdmin, canManageCenter } = usePermissions();
 
   useEffect(() => {
     cargarCentro();
     cargarArboles();
+    cargarDispositivos();
 
     // Mostrar mensaje de éxito si viene del formulario
     if (location.state?.mensaje) {
@@ -65,6 +70,30 @@ function DetalleCentro() {
     } catch (err) {
       console.error('Error cargando árboles:', err);
       // No mostramos error aquí, puede ser que simplemente no tenga árboles
+    }
+  };
+
+  const cargarDispositivos = async () => {
+    try {
+      const dispositivosData = await getDispositivosByCentro(id);
+      setDispositivos(dispositivosData);
+    } catch (err) {
+      console.error('Error cargando dispositivos:', err);
+    }
+  };
+
+  const handleEliminarDispositivo = async () => {
+    if (!dispositivoAEliminar) return;
+    try {
+      await deleteDispositivo(dispositivoAEliminar.id);
+      setDispositivos(prev => prev.filter(d => d.id !== dispositivoAEliminar.id));
+      setSuccessMessage('Dispositivo eliminado correctamente');
+    } catch (err) {
+      console.error('Error eliminando dispositivo:', err);
+      setError('No se pudo eliminar el dispositivo.');
+    } finally {
+      setShowDeleteDispositivoModal(false);
+      setDispositivoAEliminar(null);
     }
   };
 
@@ -347,6 +376,144 @@ function DetalleCentro() {
           </div>
         )}
       </div>
+
+      {/* Dispositivos del Centro */}
+      <div className="mt-6 bg-white rounded-lg shadow p-6">
+        <div className="flex items-center justify-between mb-4 border-b pb-2">
+          <h2 className="text-xl font-semibold text-gray-800">
+            Dispositivos ESP32 ({dispositivos.length})
+          </h2>
+          {canManageCenter(centro.id) && (
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => navigate('/dispositivos/nuevo', { state: { centroId: centro.id } })}
+            >
+              <Plus className="w-4 h-4 mr-1 inline" /> Añadir Dispositivo
+            </Button>
+          )}
+        </div>
+        {dispositivos.length === 0 ? (
+          <p className="text-gray-500 text-center py-4">
+            Este centro aún no tiene dispositivos registrados.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-brand-bg-green">
+              <thead className="bg-brand-primary">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
+                    Dirección MAC
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
+                    Estado
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
+                    Frecuencia (seg)
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
+                    Última conexión
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
+                    Acciones
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-brand-bg-green">
+                {dispositivos.map((dispositivo) => (
+                  <tr key={dispositivo.id} className="hover:bg-brand-primary/5">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm font-mono font-medium text-gray-900">
+                      {dispositivo.macAddress}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm">
+                      <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                        dispositivo.activo
+                          ? 'bg-green-100 text-green-800'
+                          : 'bg-gray-100 text-gray-600'
+                      }`}>
+                        {dispositivo.activo ? 'Activo' : 'Inactivo'}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {dispositivo.frecuenciaLecturaSeg} s
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {dispositivo.ultimaConexion
+                        ? new Date(dispositivo.ultimaConexion).toLocaleString('es-ES', {
+                            day: '2-digit', month: '2-digit', year: 'numeric',
+                            hour: '2-digit', minute: '2-digit',
+                          })
+                        : 'Nunca'}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm">
+                      <div className="flex gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => navigate(`/dispositivos/${dispositivo.id}/lecturas`)}
+                        >
+                          Histórico
+                        </Button>
+                        {canManageCenter(centro.id) && (
+                          <>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => navigate(`/dispositivos/${dispositivo.id}/editar`)}
+                            >
+                              Editar
+                            </Button>
+                            {isAdmin() && (
+                              <Button
+                                variant="danger"
+                                size="sm"
+                                onClick={() => {
+                                  setDispositivoAEliminar(dispositivo);
+                                  setShowDeleteDispositivoModal(true);
+                                }}
+                              >
+                                Eliminar
+                              </Button>
+                            )}
+                          </>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Modal de confirmación para eliminar dispositivo */}
+      {showDeleteDispositivoModal && dispositivoAEliminar && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+            <h3 className="text-lg font-semibold text-gray-900 mb-2">
+              Confirmar Eliminación
+            </h3>
+            <p className="text-gray-600 mb-4">
+              ¿Estás seguro de que deseas eliminar el dispositivo{' '}
+              <strong className="font-mono">{dispositivoAEliminar.macAddress}</strong>?
+            </p>
+            <div className="bg-red-50 border border-red-200 rounded p-3 mb-4">
+              <p className="text-sm text-red-800">
+                Se eliminarán también todas sus lecturas y alertas asociadas.
+              </p>
+            </div>
+            <div className="flex gap-3 justify-end">
+              <Button onClick={() => { setShowDeleteDispositivoModal(false); setDispositivoAEliminar(null); }} variant="outline">
+                Cancelar
+              </Button>
+              <Button onClick={handleEliminarDispositivo} variant="danger">
+                Eliminar
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Modal de confirmación para eliminar */}
       {showDeleteModal && (

--- a/frontend/src/pages/centros/DetalleCentro.jsx
+++ b/frontend/src/pages/centros/DetalleCentro.jsx
@@ -302,81 +302,6 @@ function DetalleCentro() {
         </div>
       </div>
 
-      {/* Árboles del Centro */}
-      <div className="mt-6 bg-white rounded-lg shadow p-6">
-        <div className="flex items-center justify-between mb-4 border-b pb-2">
-          <h2 className="text-xl font-semibold text-gray-800">
-            Árboles del Centro ({arboles.length})
-          </h2>
-          {canManageCenter(centro.id) && (
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={() => navigate('/arboles/nuevo', { state: { centroId: centro.id } })}
-            >
-              <Plus className="w-4 h-4 mr-1 inline" /> Añadir Árbol
-            </Button>
-          )}
-        </div>
-        {arboles.length === 0 ? (
-          <p className="text-gray-500 text-center py-4">
-            Este centro aún no tiene árboles registrados.
-          </p>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-brand-bg-green">
-              <thead className="bg-brand-primary">
-                <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
-                    Nombre
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
-                    Especie
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
-                    Ubicación
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
-                    Acciones
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-brand-bg-green">
-                {arboles.map((arbol) => (
-                  <tr
-                    key={arbol.id}
-                    className="hover:bg-brand-primary/5 cursor-pointer"
-                    onClick={() => handleVerArbol(arbol.id)}
-                  >
-                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                      {arbol.nombre}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      {arbol.especie}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      {arbol.ubicacionEspecifica || '-'}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleVerArbol(arbol.id);
-                        }}
-                      >
-                        Ver Detalle
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
-
       {/* Dispositivos del Centro */}
       <div className="mt-6 bg-white rounded-lg shadow p-6">
         <div className="flex items-center justify-between mb-4 border-b pb-2">
@@ -414,7 +339,7 @@ function DetalleCentro() {
                   <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
                     Última conexión
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
+                  <th className="px-6 py-3 text-right text-xs font-medium text-white uppercase tracking-wider">
                     Acciones
                   </th>
                 </tr>
@@ -446,7 +371,7 @@ function DetalleCentro() {
                         : 'Nunca'}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm">
-                      <div className="flex gap-2">
+                      <div className="flex gap-2 justify-end">
                         <Button
                           variant="outline"
                           size="sm"
@@ -478,6 +403,82 @@ function DetalleCentro() {
                           </>
                         )}
                       </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+
+      {/* Árboles del Centro */}
+      <div className="mt-6 bg-white rounded-lg shadow p-6">
+        <div className="flex items-center justify-between mb-4 border-b pb-2">
+          <h2 className="text-xl font-semibold text-gray-800">
+            Árboles del Centro ({arboles.length})
+          </h2>
+          {canManageCenter(centro.id) && (
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => navigate('/arboles/nuevo', { state: { centroId: centro.id } })}
+            >
+              <Plus className="w-4 h-4 mr-1 inline" /> Añadir Árbol
+            </Button>
+          )}
+        </div>
+        {arboles.length === 0 ? (
+          <p className="text-gray-500 text-center py-4">
+            Este centro aún no tiene árboles registrados.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-brand-bg-green">
+              <thead className="bg-brand-primary">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
+                    Nombre
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
+                    Especie
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
+                    Ubicación
+                  </th>
+                  <th className="px-6 py-3 text-right text-xs font-medium text-white uppercase tracking-wider">
+                    Acciones
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-brand-bg-green">
+                {arboles.map((arbol) => (
+                  <tr
+                    key={arbol.id}
+                    className="hover:bg-brand-primary/5 cursor-pointer"
+                    onClick={() => handleVerArbol(arbol.id)}
+                  >
+                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                      {arbol.nombre}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {arbol.especie}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {arbol.ubicacionEspecifica || '-'}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-right">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleVerArbol(arbol.id);
+                        }}
+                      >
+                        Ver Detalle
+                      </Button>
                     </td>
                   </tr>
                 ))}

--- a/frontend/src/pages/dispositivos/FormularioDispositivo.jsx
+++ b/frontend/src/pages/dispositivos/FormularioDispositivo.jsx
@@ -21,6 +21,12 @@ function FormularioDispositivo() {
     centroEducativo: { id: centroIdDesdeState || '' },
     activo: true,
     frecuenciaLecturaSeg: 30,
+    umbralTempMin: '',
+    umbralTempMax: '',
+    umbralHumedadAmbienteMin: '',
+    umbralHumedadAmbienteMax: '',
+    umbralHumedadSueloMin: '',
+    umbralCO2Max: '',
   });
 
   const [centros, setCentros] = useState([]);
@@ -52,6 +58,12 @@ function FormularioDispositivo() {
           centroEducativo: { id: dispositivoData.centroEducativo?.id || '' },
           activo: dispositivoData.activo ?? true,
           frecuenciaLecturaSeg: dispositivoData.frecuenciaLecturaSeg ?? 30,
+          umbralTempMin: dispositivoData.umbralTempMin ?? '',
+          umbralTempMax: dispositivoData.umbralTempMax ?? '',
+          umbralHumedadAmbienteMin: dispositivoData.umbralHumedadAmbienteMin ?? '',
+          umbralHumedadAmbienteMax: dispositivoData.umbralHumedadAmbienteMax ?? '',
+          umbralHumedadSueloMin: dispositivoData.umbralHumedadSueloMin ?? '',
+          umbralCO2Max: dispositivoData.umbralCO2Max ?? '',
         });
       }
     } catch (err) {
@@ -121,6 +133,12 @@ function FormularioDispositivo() {
         centroEducativo: { id: parseInt(formData.centroEducativo.id) },
         activo: formData.activo,
         frecuenciaLecturaSeg: parseInt(formData.frecuenciaLecturaSeg),
+        umbralTempMin: formData.umbralTempMin !== '' ? parseFloat(formData.umbralTempMin) : null,
+        umbralTempMax: formData.umbralTempMax !== '' ? parseFloat(formData.umbralTempMax) : null,
+        umbralHumedadAmbienteMin: formData.umbralHumedadAmbienteMin !== '' ? parseFloat(formData.umbralHumedadAmbienteMin) : null,
+        umbralHumedadAmbienteMax: formData.umbralHumedadAmbienteMax !== '' ? parseFloat(formData.umbralHumedadAmbienteMax) : null,
+        umbralHumedadSueloMin: formData.umbralHumedadSueloMin !== '' ? parseFloat(formData.umbralHumedadSueloMin) : null,
+        umbralCO2Max: formData.umbralCO2Max !== '' ? parseFloat(formData.umbralCO2Max) : null,
       };
 
       if (isEditMode) {
@@ -260,6 +278,76 @@ function FormularioDispositivo() {
               <label htmlFor="activo" className="text-sm font-medium text-gray-700">
                 Dispositivo activo
               </label>
+            </div>
+          </div>
+
+          {/* Umbrales de Monitorización */}
+          <div className="pt-6 mt-6 border-t border-gray-200">
+            <h2 className="text-lg font-semibold text-gray-800 mb-1">Umbrales de Monitorización</h2>
+            <p className="text-sm text-gray-500 mb-4">
+              El sistema generará alertas cuando los valores del sensor superen estos rangos.
+            </p>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <Input
+                id="umbralTempMin"
+                name="umbralTempMin"
+                label="Temperatura Mínima (°C)"
+                type="number"
+                step="0.1"
+                value={formData.umbralTempMin}
+                onChange={handleChange}
+                placeholder="Ej: 5"
+              />
+              <Input
+                id="umbralTempMax"
+                name="umbralTempMax"
+                label="Temperatura Máxima (°C)"
+                type="number"
+                step="0.1"
+                value={formData.umbralTempMax}
+                onChange={handleChange}
+                placeholder="Ej: 40"
+              />
+              <Input
+                id="umbralHumedadAmbienteMin"
+                name="umbralHumedadAmbienteMin"
+                label="Humedad Ambiente Mínima (%)"
+                type="number"
+                step="0.1"
+                value={formData.umbralHumedadAmbienteMin}
+                onChange={handleChange}
+                placeholder="Ej: 30"
+              />
+              <Input
+                id="umbralHumedadAmbienteMax"
+                name="umbralHumedadAmbienteMax"
+                label="Humedad Ambiente Máxima (%)"
+                type="number"
+                step="0.1"
+                value={formData.umbralHumedadAmbienteMax}
+                onChange={handleChange}
+                placeholder="Ej: 90"
+              />
+              <Input
+                id="umbralHumedadSueloMin"
+                name="umbralHumedadSueloMin"
+                label="Humedad Suelo Mínima (%)"
+                type="number"
+                step="0.1"
+                value={formData.umbralHumedadSueloMin}
+                onChange={handleChange}
+                placeholder="Ej: 30"
+              />
+              <Input
+                id="umbralCO2Max"
+                name="umbralCO2Max"
+                label="CO2 Máximo (ppm)"
+                type="number"
+                step="1"
+                value={formData.umbralCO2Max}
+                onChange={handleChange}
+                placeholder="Ej: 1000"
+              />
             </div>
           </div>
 

--- a/frontend/src/pages/dispositivos/FormularioDispositivo.jsx
+++ b/frontend/src/pages/dispositivos/FormularioDispositivo.jsx
@@ -1,0 +1,292 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { getDispositivoById, createDispositivo, updateDispositivo } from '../../services/dispositivosService';
+import { getCentros } from '../../services/centrosService';
+import Input from '../../components/common/Input';
+import Button from '../../components/common/Button';
+import Spinner from '../../components/common/Spinner';
+import Alert from '../../components/common/Alert';
+import { usePermissions } from '../../hooks/usePermissions';
+import { useAuth } from '../../context/AuthContext';
+
+function FormularioDispositivo() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const isEditMode = Boolean(id);
+
+  const centroIdDesdeState = location.state?.centroId;
+  const [formData, setFormData] = useState({
+    macAddress: '',
+    centroEducativo: { id: centroIdDesdeState || '' },
+    activo: true,
+    frecuenciaLecturaSeg: 30,
+  });
+
+  const [centros, setCentros] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [loadingData, setLoadingData] = useState(isEditMode);
+  const [error, setError] = useState('');
+  const [errors, setErrors] = useState({});
+  const { isAdmin } = usePermissions();
+  const { user } = useAuth();
+
+  const centrosFiltrados = isAdmin()
+    ? centros
+    : centros.filter(c => user?.centros?.some(uc => uc.centroId === c.id));
+
+  useEffect(() => {
+    cargarDatosIniciales();
+  }, [id]);
+
+  const cargarDatosIniciales = async () => {
+    try {
+      const centrosData = await getCentros();
+      setCentros(centrosData);
+
+      if (isEditMode) {
+        setLoadingData(true);
+        const dispositivoData = await getDispositivoById(id);
+        setFormData({
+          macAddress: dispositivoData.macAddress || '',
+          centroEducativo: { id: dispositivoData.centroEducativo?.id || '' },
+          activo: dispositivoData.activo ?? true,
+          frecuenciaLecturaSeg: dispositivoData.frecuenciaLecturaSeg ?? 30,
+        });
+      }
+    } catch (err) {
+      console.error('Error cargando datos iniciales:', err);
+      setError('No se pudo conectar con el servidor. Si es la primera carga, puede estar iniciándose (30-60 seg). Recarga la página en unos momentos.');
+    } finally {
+      setLoadingData(false);
+    }
+  };
+
+  const handleChange = (e) => {
+    const { name, value, type, checked } = e.target;
+
+    if (name === 'centroEducativo') {
+      setFormData(prev => ({ ...prev, centroEducativo: { id: value } }));
+    } else if (type === 'checkbox') {
+      setFormData(prev => ({ ...prev, [name]: checked }));
+    } else {
+      setFormData(prev => ({ ...prev, [name]: value }));
+    }
+
+    if (errors[name]) {
+      setErrors(prev => ({ ...prev, [name]: '' }));
+    }
+  };
+
+  const validarFormulario = () => {
+    const nuevosErrores = {};
+
+    if (!formData.macAddress.trim()) {
+      nuevosErrores.macAddress = 'La dirección MAC es obligatoria';
+    } else {
+      // Formato MAC: XX:XX:XX:XX:XX:XX
+      const macRegex = /^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$/;
+      if (!macRegex.test(formData.macAddress.trim())) {
+        nuevosErrores.macAddress = 'Formato incorrecto. Usa XX:XX:XX:XX:XX:XX';
+      }
+    }
+
+    if (!formData.centroEducativo.id) {
+      nuevosErrores.centroEducativo = 'Debes seleccionar un centro educativo';
+    }
+
+    const freq = parseInt(formData.frecuenciaLecturaSeg);
+    if (isNaN(freq) || freq < 5 || freq > 3600) {
+      nuevosErrores.frecuenciaLecturaSeg = 'La frecuencia debe estar entre 5 y 3600 segundos';
+    }
+
+    setErrors(nuevosErrores);
+    return Object.keys(nuevosErrores).length === 0;
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    if (!validarFormulario()) {
+      setError('Por favor, corrige los errores en el formulario');
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError('');
+
+      const dataToSend = {
+        macAddress: formData.macAddress.trim().toUpperCase(),
+        centroEducativo: { id: parseInt(formData.centroEducativo.id) },
+        activo: formData.activo,
+        frecuenciaLecturaSeg: parseInt(formData.frecuenciaLecturaSeg),
+      };
+
+      if (isEditMode) {
+        await updateDispositivo(id, dataToSend);
+        navigate(-1, { state: { mensaje: 'Dispositivo actualizado correctamente' } });
+      } else {
+        const nuevo = await createDispositivo(dataToSend);
+        navigate(`/centros/${nuevo.centroEducativo.id}`, {
+          state: { mensaje: 'Dispositivo registrado correctamente' }
+        });
+      }
+    } catch (err) {
+      console.error('Error guardando dispositivo:', err);
+      if (err.response?.status === 409) {
+        setErrors(prev => ({ ...prev, macAddress: 'Ya existe un dispositivo con esa dirección MAC' }));
+      }
+      setError(
+        err.response?.data?.message ||
+        `Error al ${isEditMode ? 'actualizar' : 'registrar'} el dispositivo. Por favor, intenta de nuevo.`
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    navigate(-1);
+  };
+
+  if (loadingData) {
+    return (
+      <div className="flex justify-center items-center py-12">
+        <Spinner size="lg" text="Cargando datos..." />
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="max-w-2xl mx-auto">
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold text-gray-800">
+            {isEditMode ? 'Editar Dispositivo' : 'Nuevo Dispositivo'}
+          </h1>
+          <p className="text-gray-600 mt-1">
+            {isEditMode
+              ? 'Modifica los datos del dispositivo ESP32'
+              : 'Registra un nuevo dispositivo ESP32 en el sistema'}
+          </p>
+        </div>
+
+        {error && (
+          <div className="mb-4">
+            <Alert
+              type="error"
+              message={error}
+              onClose={() => setError('')}
+              dismissible
+            />
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow-md p-6">
+          <div className="space-y-5">
+            {/* Dirección MAC */}
+            <Input
+              id="macAddress"
+              name="macAddress"
+              label="Dirección MAC"
+              type="text"
+              value={formData.macAddress}
+              onChange={handleChange}
+              error={errors.macAddress}
+              required
+              placeholder="Ej: AA:BB:CC:DD:EE:FF"
+            />
+            <p className="text-xs text-gray-500 -mt-3">
+              Dirección MAC del chip ESP32 (visible en el monitor serie)
+            </p>
+
+            {/* Centro Educativo */}
+            <div>
+              <label htmlFor="centroEducativo" className="block text-sm font-medium text-gray-700 mb-1">
+                Centro Educativo <span className="text-red-500">*</span>
+              </label>
+              <select
+                id="centroEducativo"
+                name="centroEducativo"
+                value={formData.centroEducativo.id}
+                onChange={handleChange}
+                className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-brand-primary ${
+                  errors.centroEducativo ? 'border-red-500' : 'border-gray-300'
+                }`}
+                required
+              >
+                <option value="">Selecciona un centro</option>
+                {centrosFiltrados.map(centro => (
+                  <option key={centro.id} value={centro.id}>
+                    {centro.nombre}
+                  </option>
+                ))}
+              </select>
+              {errors.centroEducativo && (
+                <p className="mt-1 text-sm text-red-500">{errors.centroEducativo}</p>
+              )}
+            </div>
+
+            {/* Frecuencia de lectura */}
+            <div>
+              <Input
+                id="frecuenciaLecturaSeg"
+                name="frecuenciaLecturaSeg"
+                label="Frecuencia de lectura (segundos)"
+                type="number"
+                min="5"
+                max="3600"
+                value={formData.frecuenciaLecturaSeg}
+                onChange={handleChange}
+                error={errors.frecuenciaLecturaSeg}
+                required
+              />
+              <p className="text-xs text-gray-500 mt-1">
+                Intervalo entre lecturas. Mínimo 5 s, máximo 3600 s (1 hora).
+              </p>
+            </div>
+
+            {/* Estado activo */}
+            <div className="flex items-center gap-3">
+              <input
+                id="activo"
+                name="activo"
+                type="checkbox"
+                checked={formData.activo}
+                onChange={handleChange}
+                className="h-4 w-4 rounded border-gray-300 text-brand-primary focus:ring-brand-primary"
+              />
+              <label htmlFor="activo" className="text-sm font-medium text-gray-700">
+                Dispositivo activo
+              </label>
+            </div>
+          </div>
+
+          {/* Botones de acción */}
+          <div className="flex gap-3 justify-end pt-6 mt-6 border-t border-gray-200">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleCancel}
+              disabled={loading}
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={loading}
+            >
+              {loading
+                ? (isEditMode ? 'Actualizando...' : 'Registrando...')
+                : (isEditMode ? 'Actualizar Dispositivo' : 'Registrar Dispositivo')}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default FormularioDispositivo;

--- a/frontend/src/pages/dispositivos/HistoricoDispositivo.jsx
+++ b/frontend/src/pages/dispositivos/HistoricoDispositivo.jsx
@@ -1,0 +1,463 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import { getDispositivoById } from '../../services/dispositivosService';
+import { getLecturasParaGrafica, getLecturasByDispositivoRango } from '../../services/lecturasService';
+import Spinner from '../../components/common/Spinner';
+import Alert from '../../components/common/Alert';
+import Button from '../../components/common/Button';
+
+const PAGE_SIZE = 20;
+
+const PERIODOS = [
+  { key: 'DIA',      label: 'Hoy',     info: 'cada 5 min', dias: 1   },
+  { key: 'SEMANA',   label: '7 días',  info: 'cada hora',  dias: 7   },
+  { key: 'MES',      label: '30 días', info: 'cada 6 h',   dias: 30  },
+  { key: 'SEMESTRE', label: '6 meses', info: 'diario',     dias: 180 },
+  { key: 'ANIO',     label: '1 año',   info: 'diario',     dias: 365 },
+];
+
+function calcularRango(dias) {
+  const hasta = new Date();
+  const desde = new Date(hasta.getTime() - dias * 24 * 60 * 60 * 1000);
+  return {
+    desdeISO: desde.toISOString().slice(0, 19),
+    hastaISO: hasta.toISOString().slice(0, 19),
+  };
+}
+
+function formatTimestamp(ts) {
+  if (!ts) return '-';
+  return new Date(ts).toLocaleString('es-ES', {
+    day: '2-digit', month: '2-digit', year: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+function formatTimestampShort(ts) {
+  if (!ts) return '-';
+  return new Date(ts).toLocaleString('es-ES', {
+    day: '2-digit', month: '2-digit',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+function HistoricoDispositivo() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  const [dispositivo, setDispositivo] = useState(null);
+  const [error, setError] = useState('');
+  const [intervaloSeg, setIntervaloSeg] = useState(30);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const [periodoActivo, setPeriodoActivo] = useState('SEMANA');
+
+  const [datosGrafica, setDatosGrafica] = useState([]);
+  const [loadingGrafica, setLoadingGrafica] = useState(false);
+
+  const [lecturas, setLecturas] = useState([]);
+  const [loadingTabla, setLoadingTabla] = useState(false);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [totalElements, setTotalElements] = useState(0);
+
+  // Carga del dispositivo (solo una vez)
+  useEffect(() => {
+    getDispositivoById(id)
+      .then((data) => {
+        setDispositivo(data);
+        const seg = data?.frecuenciaLecturaSeg;
+        if (seg && seg > 0) setIntervaloSeg(seg);
+      })
+      .catch(() => setError('No se pudo cargar la información del dispositivo.'));
+  }, [id]);
+
+  // Polling
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setRefreshKey((k) => k + 1);
+    }, intervaloSeg * 1000);
+    return () => clearInterval(timer);
+  }, [intervaloSeg]);
+
+  // Gráfica
+  useEffect(() => {
+    let cancelled = false;
+    const fetch = async () => {
+      setLoadingGrafica(true);
+      try {
+        const data = await getLecturasParaGrafica(id, periodoActivo);
+        if (!cancelled) {
+          setDatosGrafica(
+            data.map((item) => ({
+              tiempo: formatTimestampShort(item.timestamp),
+              temperatura: item.temperatura != null ? parseFloat(item.temperatura) : null,
+              humedadAmbiente: item.humedadAmbiente != null ? parseFloat(item.humedadAmbiente) : null,
+              humedadSuelo: item.humedadSuelo != null ? parseFloat(item.humedadSuelo) : null,
+              co2: item.co2 != null ? parseFloat(item.co2) : null,
+              luz1: item.luz1 != null ? parseFloat(item.luz1) : null,
+              luz2: item.luz2 != null ? parseFloat(item.luz2) : null,
+            }))
+          );
+        }
+      } catch {
+        if (!cancelled) setDatosGrafica([]);
+      } finally {
+        if (!cancelled) setLoadingGrafica(false);
+      }
+    };
+    fetch();
+    return () => { cancelled = true; };
+  }, [id, periodoActivo, refreshKey]);
+
+  // Tabla
+  useEffect(() => {
+    let cancelled = false;
+    const fetch = async () => {
+      const config = PERIODOS.find((p) => p.key === periodoActivo);
+      const { desdeISO, hastaISO } = calcularRango(config.dias);
+      setLoadingTabla(true);
+      try {
+        const data = await getLecturasByDispositivoRango(id, desdeISO, hastaISO, currentPage, PAGE_SIZE);
+        if (!cancelled) {
+          setLecturas(data.content);
+          setTotalPages(data.totalPages);
+          setTotalElements(data.totalElements);
+        }
+      } catch {
+        if (!cancelled) setError('No se pudieron cargar las lecturas. Inténtalo de nuevo.');
+      } finally {
+        if (!cancelled) setLoadingTabla(false);
+      }
+    };
+    fetch();
+    return () => { cancelled = true; };
+  }, [id, periodoActivo, currentPage, refreshKey]);
+
+  const handlePeriodoChange = (key) => {
+    setPeriodoActivo(key);
+    setCurrentPage(0);
+  };
+
+  const periodoConfig = PERIODOS.find((p) => p.key === periodoActivo);
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      {/* Cabecera */}
+      <div className="mb-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-800">Histórico de lecturas</h1>
+          {dispositivo && (
+            <p className="text-gray-600 mt-1">
+              Dispositivo <span className="font-mono">{dispositivo.macAddress}</span>
+              {dispositivo.centroEducativo?.nombre && (
+                <span className="text-gray-400"> · {dispositivo.centroEducativo.nombre}</span>
+              )}
+            </p>
+          )}
+        </div>
+        <Button variant="outline" onClick={() => navigate(-1)}>
+          ← Volver
+        </Button>
+      </div>
+
+      {error && (
+        <Alert type="error" message={error} dismissible onClose={() => setError('')} />
+      )}
+
+      {/* Selector de periodo */}
+      <div className="bg-white rounded-lg shadow-md p-4 mb-6">
+        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
+          Periodo
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {PERIODOS.map((p) => (
+            <button
+              key={p.key}
+              onClick={() => handlePeriodoChange(p.key)}
+              className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
+                periodoActivo === p.key
+                  ? 'bg-brand-primary text-white shadow-sm'
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+              }`}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Gráfica: Temperatura, Humedad y Luz */}
+      <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+        <div className="flex items-baseline gap-2 mb-1">
+          <h2 className="text-lg font-semibold text-gray-800">
+            Temperatura, Humedad y Luz
+          </h2>
+        </div>
+        <p className="text-xs text-gray-500 mb-4">
+          {periodoConfig.label} · {datosGrafica.length} lecturas reales
+          {datosGrafica.length === 400 && ' (muestra representativa)'}
+        </p>
+
+        {loadingGrafica ? (
+          <div className="flex justify-center py-10">
+            <Spinner size="md" text="Cargando gráfica..." />
+          </div>
+        ) : datosGrafica.length === 0 ? (
+          <p className="text-center text-gray-400 py-10 text-sm">
+            Sin datos en este periodo.
+          </p>
+        ) : (
+          <ResponsiveContainer width="100%" height={300}>
+            <LineChart data={datosGrafica} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis
+                dataKey="tiempo"
+                tick={{ fontSize: 11 }}
+                interval="preserveStartEnd"
+              />
+              <YAxis tick={{ fontSize: 11 }} />
+              <Tooltip
+                formatter={(value, name) =>
+                  value != null ? [`${value}`, name] : ['-', name]
+                }
+              />
+              <Legend />
+              <Line
+                type="monotone"
+                dataKey="temperatura"
+                name="Temperatura (°C)"
+                stroke="#f97316"
+                dot={false}
+                connectNulls
+              />
+              <Line
+                type="monotone"
+                dataKey="humedadAmbiente"
+                name="Humedad Amb. (%)"
+                stroke="#3b82f6"
+                dot={false}
+                connectNulls
+              />
+              <Line
+                type="monotone"
+                dataKey="humedadSuelo"
+                name="Humedad Suelo (%)"
+                stroke="#22c55e"
+                dot={false}
+                connectNulls
+              />
+              <Line
+                type="monotone"
+                dataKey="luz1"
+                name="Luz 1 (%)"
+                stroke="#eab308"
+                dot={false}
+                connectNulls
+              />
+              <Line
+                type="monotone"
+                dataKey="luz2"
+                name="Luz 2 (%)"
+                stroke="#a855f7"
+                dot={false}
+                connectNulls
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      {/* Gráfica CO2 */}
+      <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+        <div className="flex items-baseline gap-2 mb-1">
+          <h2 className="text-lg font-semibold text-gray-800">CO2</h2>
+        </div>
+        <p className="text-xs text-gray-500 mb-4">
+          {periodoConfig.label} · {datosGrafica.filter(d => d.co2 != null).length} lecturas con datos
+        </p>
+
+        {loadingGrafica ? (
+          <div className="flex justify-center py-10">
+            <Spinner size="md" text="Cargando gráfica..." />
+          </div>
+        ) : datosGrafica.filter(d => d.co2 != null).length === 0 ? (
+          <p className="text-center text-gray-400 py-10 text-sm">
+            Sin datos de CO2 en este periodo.
+          </p>
+        ) : (
+          <ResponsiveContainer width="100%" height={200}>
+            <LineChart data={datosGrafica} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis
+                dataKey="tiempo"
+                tick={{ fontSize: 11 }}
+                interval="preserveStartEnd"
+              />
+              <YAxis tick={{ fontSize: 11 }} unit=" ppm" />
+              <Tooltip
+                formatter={(value, name) =>
+                  value != null ? [`${value} ppm`, name] : ['-', name]
+                }
+              />
+              <Legend />
+              <Line
+                type="monotone"
+                dataKey="co2"
+                name="CO2 (ppm)"
+                stroke="#ef4444"
+                dot={false}
+                connectNulls
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      {/* Tabla de lecturas raw paginadas */}
+      <div className="bg-white rounded-lg shadow-md overflow-hidden">
+        <div className="p-6 pb-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <h2 className="text-lg font-semibold text-gray-800">
+            Lecturas individuales
+            <span className="ml-2 text-sm font-normal text-gray-500">
+              ({totalElements} en este periodo)
+            </span>
+          </h2>
+          <Paginacion
+            currentPage={currentPage}
+            totalPages={totalPages}
+            loading={loadingTabla}
+            onPageChange={setCurrentPage}
+          />
+        </div>
+
+        {loadingTabla ? (
+          <div className="flex justify-center py-8">
+            <Spinner size="md" text="Cargando..." />
+          </div>
+        ) : lecturas.length === 0 ? (
+          <p className="text-center text-gray-500 py-8 text-sm italic">
+            No hay lecturas registradas en este periodo.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-brand-bg-green text-sm">
+              <thead className="bg-brand-primary">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
+                    Fecha/Hora
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-white uppercase tracking-wider">
+                    Temp. (°C)
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-white uppercase tracking-wider">
+                    Hum. Ambiente (%)
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-white uppercase tracking-wider">
+                    Hum. Suelo (%)
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-white uppercase tracking-wider">
+                    CO2 (ppm)
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-white uppercase tracking-wider">
+                    Luz 1 (%)
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs font-medium text-white uppercase tracking-wider">
+                    Luz 2 (%)
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-brand-bg-green">
+                {lecturas.map((lectura) => (
+                  <tr key={lectura.id} className="hover:bg-brand-primary/5">
+                    <td className="px-4 py-3 text-gray-700 whitespace-nowrap">
+                      {formatTimestamp(lectura.timestamp)}
+                    </td>
+                    <td className="px-4 py-3 text-right text-gray-700">
+                      {lectura.temperatura != null
+                        ? parseFloat(lectura.temperatura).toFixed(1)
+                        : '-'}
+                    </td>
+                    <td className="px-4 py-3 text-right text-gray-700">
+                      {lectura.humedadAmbiente != null
+                        ? parseFloat(lectura.humedadAmbiente).toFixed(1)
+                        : '-'}
+                    </td>
+                    <td className="px-4 py-3 text-right text-gray-700">
+                      {lectura.humedadSuelo != null
+                        ? parseFloat(lectura.humedadSuelo).toFixed(1)
+                        : '-'}
+                    </td>
+                    <td className="px-4 py-3 text-right text-gray-700">
+                      {lectura.co2 != null
+                        ? parseFloat(lectura.co2).toFixed(0)
+                        : '-'}
+                    </td>
+                    <td className="px-4 py-3 text-right text-gray-700">
+                      {lectura.luz1 != null
+                        ? parseFloat(lectura.luz1).toFixed(1)
+                        : '-'}
+                    </td>
+                    <td className="px-4 py-3 text-right text-gray-700">
+                      {lectura.luz2 != null
+                        ? parseFloat(lectura.luz2).toFixed(1)
+                        : '-'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {totalPages > 1 && (
+          <div className="p-4 border-t border-gray-100 flex justify-end">
+            <Paginacion
+              currentPage={currentPage}
+              totalPages={totalPages}
+              loading={loadingTabla}
+              onPageChange={setCurrentPage}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Paginacion({ currentPage, totalPages, loading, onPageChange }) {
+  if (totalPages <= 1) return null;
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 0 || loading}
+        className="px-3 py-1.5 text-sm rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-100 transition-colors"
+      >
+        ← Anterior
+      </button>
+      <span className="text-sm text-gray-600 whitespace-nowrap">
+        Página {currentPage + 1} de {totalPages}
+      </span>
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage >= totalPages - 1 || loading}
+        className="px-3 py-1.5 text-sm rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-100 transition-colors"
+      >
+        Siguiente →
+      </button>
+    </div>
+  );
+}
+
+export default HistoricoDispositivo;

--- a/frontend/src/services/dispositivosService.js
+++ b/frontend/src/services/dispositivosService.js
@@ -1,0 +1,95 @@
+import api from "./api";
+
+/**
+ * Servicio para gestionar operaciones CRUD de dispositivos ESP32
+ */
+
+/**
+ * Obtener todos los dispositivos ESP32
+ * @returns {Promise<Array>} Lista de dispositivos
+ */
+export const getDispositivos = async () => {
+  try {
+    const response = await api.get('/dispositivos');
+    return response.data;
+  } catch (error) {
+    console.error('Error obteniendo dispositivos', error);
+    throw error;
+  }
+};
+
+/**
+ * Obtener un dispositivo ESP32 por su ID
+ * @param {number} id - ID del dispositivo
+ * @returns {Promise<Object>} Datos del dispositivo
+ */
+export const getDispositivoById = async (id) => {
+  try {
+    const response = await api.get(`/dispositivos/${id}`);
+    return response.data;
+  } catch (error) {
+    console.error(`Error obteniendo dispositivo ${id}`, error);
+    throw error;
+  }
+};
+
+/**
+ * Obtener los dispositivos de un centro educativo
+ * @param {number} centroId - ID del centro educativo
+ * @returns {Promise<Array>} Lista de dispositivos del centro
+ */
+export const getDispositivosByCentro = async (centroId) => {
+  try {
+    const response = await api.get(`/dispositivos/centro/${centroId}`);
+    return response.data;
+  } catch (error) {
+    console.error(`Error obteniendo dispositivos del centro ${centroId}`, error);
+    throw error;
+  }
+};
+
+/**
+ * Crear un nuevo dispositivo ESP32
+ * @param {Object} dispositivoData - Datos del dispositivo a crear
+ * @returns {Promise<Object>} Dispositivo creado
+ */
+export const createDispositivo = async (dispositivoData) => {
+  try {
+    const response = await api.post('/dispositivos', dispositivoData);
+    return response.data;
+  } catch (error) {
+    console.error('Error creando dispositivo', error);
+    throw error;
+  }
+};
+
+/**
+ * Actualizar un dispositivo ESP32 existente
+ * @param {number} id - ID del dispositivo a actualizar
+ * @param {Object} dispositivoData - Nuevos datos del dispositivo
+ * @returns {Promise<Object>} Dispositivo actualizado
+ */
+export const updateDispositivo = async (id, dispositivoData) => {
+  try {
+    const response = await api.put(`/dispositivos/${id}`, dispositivoData);
+    return response.data;
+  } catch (error) {
+    console.error(`Error actualizando dispositivo ${id}`, error);
+    throw error;
+  }
+};
+
+/**
+ * Eliminar un dispositivo ESP32
+ * @param {number} id - ID del dispositivo a eliminar
+ * @returns {Promise<Object>} Dispositivo eliminado
+ */
+export const deleteDispositivo = async (id) => {
+  try {
+    const response = await api.delete(`/dispositivos/${id}`);
+    return response.data;
+  } catch (error) {
+    console.error(`Error eliminando dispositivo ${id}`, error);
+    throw error;
+  }
+};

--- a/frontend/src/services/lecturasService.js
+++ b/frontend/src/services/lecturasService.js
@@ -1,20 +1,20 @@
 import api from "./api";
 
 /**
- * Obtener lecturas de un árbol paginadas (ordenadas DESC por timestamp).
- * @param {number} arbolId - ID del árbol
+ * Obtener lecturas de un dispositivo paginadas (ordenadas DESC por timestamp).
+ * @param {number} dispositivoId - ID del dispositivo
  * @param {number} page - Número de página (0-indexed)
  * @param {number} size - Tamaño de página
  * @returns {Promise<Page>} Objeto Page con { content, totalElements, totalPages, number, size }
  */
-export const getLecturasByArbol = async (arbolId, page = 0, size = 20) => {
+export const getLecturasByDispositivo = async (dispositivoId, page = 0, size = 20) => {
   try {
-    const response = await api.get(`/lecturas/arbol/${arbolId}`, {
+    const response = await api.get(`/lecturas/dispositivo/${dispositivoId}`, {
       params: { page, size },
     });
     return response.data;
   } catch (error) {
-    console.error(`Error obteniendo lecturas del árbol ${arbolId}`, error);
+    console.error(`Error obteniendo lecturas del dispositivo ${dispositivoId}`, error);
     throw error;
   }
 };
@@ -23,49 +23,54 @@ export const getLecturasByArbol = async (arbolId, page = 0, size = 20) => {
  * Obtener lecturas REALES muestreadas (stride sampling) para la gráfica.
  * El backend garantiza siempre ≤ ~400 puntos preservando picos y valles reales.
  *
- * @param {number} arbolId - ID del árbol
+ * @param {number} dispositivoId - ID del dispositivo
  * @param {'DIA'|'SEMANA'|'MES'|'SEMESTRE'|'ANIO'} periodo - Periodo predefinido
  * @returns {Promise<Array>} Lista de { id, timestamp, temperatura, humedadAmbiente, ... }
  */
-export const getLecturasParaGrafica = async (arbolId, periodo) => {
+export const getLecturasParaGrafica = async (dispositivoId, periodo) => {
   try {
-    const response = await api.get(`/lecturas/arbol/${arbolId}/grafica`, {
+    const response = await api.get(`/lecturas/dispositivo/${dispositivoId}/grafica`, {
       params: { periodo },
     });
     return response.data;
   } catch (error) {
-    console.error(`Error obteniendo muestra de lecturas del árbol ${arbolId}`, error);
+    console.error(`Error obteniendo muestra de lecturas del dispositivo ${dispositivoId}`, error);
     throw error;
   }
 };
 
 /**
- * Obtener la lectura más reciente de un árbol.
- * @param {number} arbolId - ID del árbol
+ * Obtener la lectura más reciente de un dispositivo.
+ * @param {number} dispositivoId - ID del dispositivo
  * @returns {Promise<Object|null>} Lectura más reciente o null si no hay ninguna
  */
-export const getUltimaLectura = async (arbolId) => {
-  const data = await getLecturasByArbol(arbolId, 0, 1);
+export const getUltimaLectura = async (dispositivoId) => {
+  const data = await getLecturasByDispositivo(dispositivoId, 0, 1);
   return data.content.length > 0 ? data.content[0] : null;
 };
 
 /**
- * Obtener lecturas de un árbol en un rango de fechas, paginadas.
- * @param {number} arbolId - ID del árbol
+ * Obtener lecturas de un dispositivo en un rango de fechas, paginadas.
+ * @param {number} dispositivoId - ID del dispositivo
  * @param {string} desde - Fecha inicio (ISO 8601)
  * @param {string} hasta - Fecha fin (ISO 8601)
  * @param {number} page - Número de página (0-indexed)
  * @param {number} size - Tamaño de página
  * @returns {Promise<Page>} Objeto Page con { content, totalElements, totalPages, number, size }
  */
-export const getLecturasByArbolRango = async (arbolId, desde, hasta, page = 0, size = 20) => {
+export const getLecturasByDispositivoRango = async (dispositivoId, desde, hasta, page = 0, size = 20) => {
   try {
-    const response = await api.get(`/lecturas/arbol/${arbolId}/rango`, {
+    const response = await api.get(`/lecturas/dispositivo/${dispositivoId}/rango`, {
       params: { desde, hasta, page, size },
     });
     return response.data;
   } catch (error) {
-    console.error(`Error obteniendo lecturas en rango para árbol ${arbolId}`, error);
+    console.error(`Error obteniendo lecturas en rango para dispositivo ${dispositivoId}`, error);
     throw error;
   }
 };
+
+// Aliases para compatibilidad con código antiguo
+export const getLecturasByArbol = getLecturasByDispositivo;
+export const getLecturasParaGraficaDispositivo = getLecturasParaGrafica;
+export const getLecturasByArbolRango = getLecturasByDispositivoRango;


### PR DESCRIPTION
## Summary

- Each `DispositivoEsp32` now belongs to a `CentroEducativo` (N:1 relation) instead of an individual tree
- Monitoring thresholds (`umbralTempMin/Max`, `umbralHumedadAmbienteMin/Max`, `umbralHumedadSueloMin`, `umbralCO2Max`) moved from `Arbol` to `DispositivoEsp32`
- Trees act as inventory items in the center; IoT data is accessed from the device
- New frontend pages: `FormularioDispositivo`, `HistoricoDispositivo`
- `DetalleCentro` now shows the center's ESP32 devices with full CRUD
- New backend endpoints: `GET /api/dispositivos/centro/{id}`, `PATCH /api/dispositivos/{id}/umbrales`
- Readings and alerts reference the device directly; `arbol_id` column removed from both tables
- Idempotent SQL migration (`migration_dispositivo_centro.sql`) applied in local and production
- All documentation updated: root README, backend README, frontend README, data model, technical spec, IoT roadmap, roadmap

## Test plan

- [ ] Create a new device from `DetalleCentro` and verify it appears in the device list
- [ ] Edit device thresholds and verify they persist
- [ ] Access `HistoricoDispositivo` and verify charts and polling work
- [ ] Verify `DetalleArbol` shows only inventory fields (no IoT section)
- [ ] Verify `FormularioArbol` has no threshold fields
- [ ] Verify existing readings (device ID 1, 122 readings) are still accessible via `HistoricoDispositivo`
- [ ] Run existing Vitest suite — all 21 tests passing