### PR TITLE
chore(frontend): remove deprecated baseUrl from jsconfig.json

### DIFF
--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "jsx": "react-jsx"
   },
   "include": ["src"]


### PR DESCRIPTION
## Summary

- Removes `baseUrl: "."` from `jsconfig.json` — was causing a deprecation warning in VS Code (TypeScript 7.0)
- No absolute imports to project files exist in the codebase, so the option was unused

## Test plan

- [x] Deprecation warning gone in VS Code
- [x] Frontend builds correctly (`npm run build`)