### PR TITLE
refactor(android): standardize form fields to TextInputLayout across all forms

### DIFF
--- a/android/app/src/main/java/com/example/proyectoarboles/fragments/CrearArbolFragment.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/fragments/CrearArbolFragment.java
@@ -39,6 +39,7 @@ public class CrearArbolFragment extends Fragment {
     private TextInputEditText inputFechaPlantacion;
     private TextInputEditText inputUbicacion;
     private Button btnCrear;
+    private Button btnCancelar;
     private ImageButton btnVolver;
     private ProgressBar progressBar;
 
@@ -73,6 +74,7 @@ public class CrearArbolFragment extends Fragment {
         inputFechaPlantacion = view.findViewById(R.id.inputFechaPlantacion);
         inputUbicacion = view.findViewById(R.id.inputUbicacion);
         btnCrear = view.findViewById(R.id.btnCrearArbol);
+        btnCancelar = view.findViewById(R.id.btnCancelarCrearArbol);
         btnVolver = view.findViewById(R.id.buttonVolverCrearArbol);
         progressBar = view.findViewById(R.id.progressBarCrear);
 
@@ -83,6 +85,8 @@ public class CrearArbolFragment extends Fragment {
         }
 
         btnCrear.setOnClickListener(v -> validarYCrearArbol());
+        btnCancelar.setOnClickListener(v ->
+                requireActivity().getSupportFragmentManager().popBackStack());
         btnVolver.setOnClickListener(v ->
                 requireActivity().getSupportFragmentManager().popBackStack());
     }

--- a/android/app/src/main/java/com/example/proyectoarboles/fragments/FormularioUsuarioFragment.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/fragments/FormularioUsuarioFragment.java
@@ -46,7 +46,7 @@ public class FormularioUsuarioFragment extends Fragment {
     private EditText editNombre;
     private EditText editEmail;
     private EditText editPassword;
-    private TextView labelPassword;
+    private View labelPassword;
     private Spinner spinnerRol;
     private SwitchCompat switchActivo;
     private ImageButton btnVolver;

--- a/android/app/src/main/res/layout/fragment_crear_arbol.xml
+++ b/android/app/src/main/res/layout/fragment_crear_arbol.xml
@@ -48,7 +48,16 @@
             style="@style/ButtonPrimary"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Crear Árbol"
+            android:text="Guardar"
+            android:textSize="12sp" />
+
+        <Button
+            android:id="@+id/btnCancelarCrearArbol"
+            style="@style/ButtonSecondary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="Cancelar"
             android:textSize="12sp" />
 
     </LinearLayout>

--- a/android/app/src/main/res/layout/fragment_formulario_centro.xml
+++ b/android/app/src/main/res/layout/fragment_formulario_centro.xml
@@ -89,55 +89,58 @@
                     android:orientation="vertical"
                     android:padding="16dp">
 
-                <!-- Nombre -->
-                <TextView
+                <com.google.android.material.textfield.TextInputLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="Nombre del Centro *"
-                    android:textStyle="bold"
-                    android:textColor="@color/text_primary"/>
-                <EditText
-                    android:id="@+id/editTextNombreCentro"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:hint="Ej: IES El Rincón"
-                    android:inputType="text"
-                    android:maxLength="200"
-                    android:layout_marginBottom="12dp"/>
+                    android:layout_marginBottom="12dp"
+                    app:boxBackgroundColor="@color/white"
+                    app:boxStrokeColor="@color/green_primary">
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/editTextNombreCentro"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="Nombre del Centro"
+                        android:inputType="text"
+                        android:maxLength="200"
+                        android:textColor="@color/black"
+                        android:textColorHint="@color/text_hint" />
+                </com.google.android.material.textfield.TextInputLayout>
 
-                <!-- Dirección -->
-                <TextView
+                <com.google.android.material.textfield.TextInputLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="Dirección *"
-                    android:textStyle="bold"
-                    android:textColor="@color/text_primary"/>
-                <EditText
-                    android:id="@+id/editTextDireccionCentro"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:hint="Ej: Calle Principal 123"
-                    android:inputType="text"
-                    android:maxLength="300"
-                    android:layout_marginBottom="12dp"/>
+                    android:layout_marginBottom="12dp"
+                    app:boxBackgroundColor="@color/white"
+                    app:boxStrokeColor="@color/green_primary">
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/editTextDireccionCentro"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="Dirección"
+                        android:inputType="text"
+                        android:maxLength="300"
+                        android:textColor="@color/black"
+                        android:textColorHint="@color/text_hint" />
+                </com.google.android.material.textfield.TextInputLayout>
 
-                <!-- Responsable -->
-                <TextView
+                <com.google.android.material.textfield.TextInputLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="Responsable *"
-                    android:textStyle="bold"
-                    android:textColor="@color/text_primary"/>
-                <EditText
-                    android:id="@+id/editTextResponsableCentro"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:hint="Ej: Juan Pérez García"
-                    android:inputType="textPersonName"
-                    android:maxLength="100"
-                    android:layout_marginBottom="12dp"/>
+                    android:layout_marginBottom="12dp"
+                    app:boxBackgroundColor="@color/white"
+                    app:boxStrokeColor="@color/green_primary">
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/editTextResponsableCentro"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="Responsable"
+                        android:inputType="textPersonName"
+                        android:maxLength="100"
+                        android:textColor="@color/black"
+                        android:textColorHint="@color/text_hint" />
+                </com.google.android.material.textfield.TextInputLayout>
 
-                <!-- Isla -->
+                <!-- Isla (Spinner no compatible con TextInputLayout) -->
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -150,52 +153,47 @@
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="12dp"/>
 
-                <!-- Población y Provincia -->
+                <!-- Población y Código Postal -->
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal">
 
-                    <LinearLayout
+                    <com.google.android.material.textfield.TextInputLayout
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:orientation="vertical"
-                        android:layout_marginEnd="8dp">
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="Población"
-                            android:textStyle="bold"
-                            android:textColor="@color/text_primary"/>
-                        <EditText
+                        android:layout_marginEnd="4dp"
+                        android:layout_marginBottom="12dp"
+                        app:boxBackgroundColor="@color/white"
+                        app:boxStrokeColor="@color/green_primary">
+                        <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/editTextPoblacion"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:hint="Ej: Las Palmas"
+                            android:hint="Población"
                             android:inputType="text"
-                            android:layout_marginBottom="12dp"/>
-                    </LinearLayout>
+                            android:textColor="@color/black"
+                            android:textColorHint="@color/text_hint" />
+                    </com.google.android.material.textfield.TextInputLayout>
 
-                    <LinearLayout
+                    <com.google.android.material.textfield.TextInputLayout
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:orientation="vertical">
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="Código Postal"
-                            android:textStyle="bold"
-                            android:textColor="@color/text_primary"/>
-                        <EditText
+                        android:layout_marginStart="4dp"
+                        android:layout_marginBottom="12dp"
+                        app:boxBackgroundColor="@color/white"
+                        app:boxStrokeColor="@color/green_primary">
+                        <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/editTextCodigoPostal"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:hint="Ej: 35001"
+                            android:hint="Código Postal"
                             android:inputType="number"
-                            android:layout_marginBottom="12dp"/>
-                    </LinearLayout>
+                            android:textColor="@color/black"
+                            android:textColorHint="@color/text_hint" />
+                    </com.google.android.material.textfield.TextInputLayout>
 
                 </LinearLayout>
 
@@ -205,46 +203,41 @@
                     android:layout_height="wrap_content"
                     android:orientation="horizontal">
 
-                    <LinearLayout
+                    <com.google.android.material.textfield.TextInputLayout
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:orientation="vertical"
-                        android:layout_marginEnd="8dp">
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="Teléfono"
-                            android:textStyle="bold"
-                            android:textColor="@color/text_primary"/>
-                        <EditText
+                        android:layout_marginEnd="4dp"
+                        android:layout_marginBottom="12dp"
+                        app:boxBackgroundColor="@color/white"
+                        app:boxStrokeColor="@color/green_primary">
+                        <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/editTextTelefonoCentro"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:hint="Ej: 928 123 456"
+                            android:hint="Teléfono"
                             android:inputType="phone"
-                            android:layout_marginBottom="12dp"/>
-                    </LinearLayout>
+                            android:textColor="@color/black"
+                            android:textColorHint="@color/text_hint" />
+                    </com.google.android.material.textfield.TextInputLayout>
 
-                    <LinearLayout
+                    <com.google.android.material.textfield.TextInputLayout
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:orientation="vertical">
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="Email"
-                            android:textStyle="bold"
-                            android:textColor="@color/text_primary"/>
-                        <EditText
+                        android:layout_marginStart="4dp"
+                        android:layout_marginBottom="12dp"
+                        app:boxBackgroundColor="@color/white"
+                        app:boxStrokeColor="@color/green_primary">
+                        <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/editTextEmailCentro"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:hint="centro@ejemplo.es"
+                            android:hint="Email"
                             android:inputType="textEmailAddress"
-                            android:layout_marginBottom="12dp"/>
-                    </LinearLayout>
+                            android:textColor="@color/black"
+                            android:textColorHint="@color/text_hint" />
+                    </com.google.android.material.textfield.TextInputLayout>
 
                 </LinearLayout>
 
@@ -254,46 +247,41 @@
                     android:layout_height="wrap_content"
                     android:orientation="horizontal">
 
-                    <LinearLayout
+                    <com.google.android.material.textfield.TextInputLayout
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:orientation="vertical"
-                        android:layout_marginEnd="8dp">
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="Latitud *"
-                            android:textStyle="bold"
-                            android:textColor="@color/text_primary"/>
-                        <EditText
+                        android:layout_marginEnd="4dp"
+                        android:layout_marginBottom="12dp"
+                        app:boxBackgroundColor="@color/white"
+                        app:boxStrokeColor="@color/green_primary">
+                        <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/editTextLatitudCentro"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:hint="Ej: 28.4636"
+                            android:hint="Latitud"
                             android:inputType="numberDecimal|numberSigned"
-                            android:layout_marginBottom="12dp"/>
-                    </LinearLayout>
+                            android:textColor="@color/black"
+                            android:textColorHint="@color/text_hint" />
+                    </com.google.android.material.textfield.TextInputLayout>
 
-                    <LinearLayout
+                    <com.google.android.material.textfield.TextInputLayout
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:orientation="vertical">
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="Longitud *"
-                            android:textStyle="bold"
-                            android:textColor="@color/text_primary"/>
-                        <EditText
+                        android:layout_marginStart="4dp"
+                        android:layout_marginBottom="12dp"
+                        app:boxBackgroundColor="@color/white"
+                        app:boxStrokeColor="@color/green_primary">
+                        <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/editTextLongitudCentro"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:hint="Ej: -16.2518"
+                            android:hint="Longitud"
                             android:inputType="numberDecimal|numberSigned"
-                            android:layout_marginBottom="12dp"/>
-                    </LinearLayout>
+                            android:textColor="@color/black"
+                            android:textColorHint="@color/text_hint" />
+                    </com.google.android.material.textfield.TextInputLayout>
 
                 </LinearLayout>
 

--- a/android/app/src/main/res/layout/fragment_formulario_dispositivo.xml
+++ b/android/app/src/main/res/layout/fragment_formulario_dispositivo.xml
@@ -92,22 +92,24 @@
                 android:orientation="vertical"
                 android:padding="16dp">
 
-                <!-- Dirección MAC -->
-                <TextView
+                <com.google.android.material.textfield.TextInputLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="Dirección MAC *"
-                    android:textStyle="bold"
-                    android:textColor="@color/text_primary"/>
-                <EditText
-                    android:id="@+id/editTextMacAddress"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:hint="Ej: AA:BB:CC:DD:EE:FF"
-                    android:inputType="text"
-                    android:fontFamily="monospace"
-                    android:maxLength="17"
-                    android:layout_marginBottom="4dp"/>
+                    android:layout_marginBottom="4dp"
+                    app:boxBackgroundColor="@color/white"
+                    app:boxStrokeColor="@color/green_primary">
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/editTextMacAddress"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="Dirección MAC (Ej: AA:BB:CC:DD:EE:FF)"
+                        android:inputType="text"
+                        android:fontFamily="monospace"
+                        android:maxLength="17"
+                        android:textColor="@color/black"
+                        android:textColorHint="@color/text_hint" />
+                </com.google.android.material.textfield.TextInputLayout>
+
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -116,11 +118,11 @@
                     android:textColor="@color/text_secondary"
                     android:layout_marginBottom="12dp"/>
 
-                <!-- Centro Educativo -->
+                <!-- Centro Educativo (Spinner no compatible con TextInputLayout) -->
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="Centro Educativo *"
+                    android:text="Centro Educativo"
                     android:textStyle="bold"
                     android:textColor="@color/text_primary"/>
                 <Spinner
@@ -129,20 +131,22 @@
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="12dp"/>
 
-                <!-- Frecuencia de lectura -->
-                <TextView
+                <com.google.android.material.textfield.TextInputLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="Frecuencia de lectura (segundos) *"
-                    android:textStyle="bold"
-                    android:textColor="@color/text_primary"/>
-                <EditText
-                    android:id="@+id/editTextFrecuencia"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:hint="30"
-                    android:inputType="number"
-                    android:layout_marginBottom="4dp"/>
+                    android:layout_marginBottom="4dp"
+                    app:boxBackgroundColor="@color/white"
+                    app:boxStrokeColor="@color/green_primary">
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/editTextFrecuencia"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="Frecuencia de lectura (segundos)"
+                        android:inputType="number"
+                        android:textColor="@color/black"
+                        android:textColorHint="@color/text_hint" />
+                </com.google.android.material.textfield.TextInputLayout>
+
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -151,7 +155,7 @@
                     android:textColor="@color/text_secondary"
                     android:layout_marginBottom="12dp"/>
 
-                <!-- Estado activo -->
+                <!-- Estado activo (CheckBox no compatible con TextInputLayout) -->
                 <CheckBox
                     android:id="@+id/checkBoxActivo"
                     android:layout_width="match_parent"
@@ -203,46 +207,41 @@
                     android:layout_height="wrap_content"
                     android:orientation="horizontal">
 
-                    <LinearLayout
+                    <com.google.android.material.textfield.TextInputLayout
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:orientation="vertical"
-                        android:layout_marginEnd="8dp">
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="Temp. Mínima (°C)"
-                            android:textSize="13sp"
-                            android:textColor="@color/text_primary"/>
-                        <EditText
+                        android:layout_marginEnd="4dp"
+                        android:layout_marginBottom="8dp"
+                        app:boxBackgroundColor="@color/white"
+                        app:boxStrokeColor="@color/green_primary">
+                        <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/editTextUmbralTempMin"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:hint="Ej: 5"
+                            android:hint="Temp. Mínima (°C)"
                             android:inputType="numberDecimal|numberSigned"
-                            android:layout_marginBottom="8dp"/>
-                    </LinearLayout>
+                            android:textColor="@color/black"
+                            android:textColorHint="@color/text_hint" />
+                    </com.google.android.material.textfield.TextInputLayout>
 
-                    <LinearLayout
+                    <com.google.android.material.textfield.TextInputLayout
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:orientation="vertical">
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="Temp. Máxima (°C)"
-                            android:textSize="13sp"
-                            android:textColor="@color/text_primary"/>
-                        <EditText
+                        android:layout_marginStart="4dp"
+                        android:layout_marginBottom="8dp"
+                        app:boxBackgroundColor="@color/white"
+                        app:boxStrokeColor="@color/green_primary">
+                        <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/editTextUmbralTempMax"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:hint="Ej: 40"
+                            android:hint="Temp. Máxima (°C)"
                             android:inputType="numberDecimal|numberSigned"
-                            android:layout_marginBottom="8dp"/>
-                    </LinearLayout>
+                            android:textColor="@color/black"
+                            android:textColorHint="@color/text_hint" />
+                    </com.google.android.material.textfield.TextInputLayout>
 
                 </LinearLayout>
 
@@ -252,46 +251,41 @@
                     android:layout_height="wrap_content"
                     android:orientation="horizontal">
 
-                    <LinearLayout
+                    <com.google.android.material.textfield.TextInputLayout
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:orientation="vertical"
-                        android:layout_marginEnd="8dp">
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="Hum. Amb. Mínima (%)"
-                            android:textSize="13sp"
-                            android:textColor="@color/text_primary"/>
-                        <EditText
+                        android:layout_marginEnd="4dp"
+                        android:layout_marginBottom="8dp"
+                        app:boxBackgroundColor="@color/white"
+                        app:boxStrokeColor="@color/green_primary">
+                        <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/editTextUmbralHumedadAmbienteMin"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:hint="Ej: 30"
+                            android:hint="Hum. Amb. Mínima (%)"
                             android:inputType="numberDecimal"
-                            android:layout_marginBottom="8dp"/>
-                    </LinearLayout>
+                            android:textColor="@color/black"
+                            android:textColorHint="@color/text_hint" />
+                    </com.google.android.material.textfield.TextInputLayout>
 
-                    <LinearLayout
+                    <com.google.android.material.textfield.TextInputLayout
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:orientation="vertical">
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="Hum. Amb. Máxima (%)"
-                            android:textSize="13sp"
-                            android:textColor="@color/text_primary"/>
-                        <EditText
+                        android:layout_marginStart="4dp"
+                        android:layout_marginBottom="8dp"
+                        app:boxBackgroundColor="@color/white"
+                        app:boxStrokeColor="@color/green_primary">
+                        <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/editTextUmbralHumedadAmbienteMax"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:hint="Ej: 90"
+                            android:hint="Hum. Amb. Máxima (%)"
                             android:inputType="numberDecimal"
-                            android:layout_marginBottom="8dp"/>
-                    </LinearLayout>
+                            android:textColor="@color/black"
+                            android:textColorHint="@color/text_hint" />
+                    </com.google.android.material.textfield.TextInputLayout>
 
                 </LinearLayout>
 
@@ -301,46 +295,41 @@
                     android:layout_height="wrap_content"
                     android:orientation="horizontal">
 
-                    <LinearLayout
+                    <com.google.android.material.textfield.TextInputLayout
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:orientation="vertical"
-                        android:layout_marginEnd="8dp">
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="Hum. Suelo Mínima (%)"
-                            android:textSize="13sp"
-                            android:textColor="@color/text_primary"/>
-                        <EditText
+                        android:layout_marginEnd="4dp"
+                        android:layout_marginBottom="8dp"
+                        app:boxBackgroundColor="@color/white"
+                        app:boxStrokeColor="@color/green_primary">
+                        <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/editTextUmbralHumedadSueloMin"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:hint="Ej: 30"
+                            android:hint="Hum. Suelo Mínima (%)"
                             android:inputType="numberDecimal"
-                            android:layout_marginBottom="8dp"/>
-                    </LinearLayout>
+                            android:textColor="@color/black"
+                            android:textColorHint="@color/text_hint" />
+                    </com.google.android.material.textfield.TextInputLayout>
 
-                    <LinearLayout
+                    <com.google.android.material.textfield.TextInputLayout
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:orientation="vertical">
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="CO2 Máximo (ppm)"
-                            android:textSize="13sp"
-                            android:textColor="@color/text_primary"/>
-                        <EditText
+                        android:layout_marginStart="4dp"
+                        android:layout_marginBottom="8dp"
+                        app:boxBackgroundColor="@color/white"
+                        app:boxStrokeColor="@color/green_primary">
+                        <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/editTextUmbralCO2Max"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:hint="Ej: 1000"
+                            android:hint="CO2 Máximo (ppm)"
                             android:inputType="number"
-                            android:layout_marginBottom="8dp"/>
-                    </LinearLayout>
+                            android:textColor="@color/black"
+                            android:textColorHint="@color/text_hint" />
+                    </com.google.android.material.textfield.TextInputLayout>
 
                 </LinearLayout>
 

--- a/android/app/src/main/res/layout/fragment_formulario_usuario.xml
+++ b/android/app/src/main/res/layout/fragment_formulario_usuario.xml
@@ -100,54 +100,55 @@
                     android:orientation="vertical"
                     android:padding="16dp">
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="4dp"
-                        android:text="Nombre"
-                        android:textColor="@color/text_primary"
-                        android:textSize="14sp" />
-
-                    <EditText
-                        android:id="@+id/editTextNombre"
+                    <com.google.android.material.textfield.TextInputLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginBottom="16dp"
-                        android:hint="Introduzca el nombre"
-                        android:inputType="textPersonName" />
+                        android:layout_marginBottom="12dp"
+                        app:boxBackgroundColor="@color/white"
+                        app:boxStrokeColor="@color/green_primary">
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/editTextNombre"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:hint="Nombre"
+                            android:inputType="textPersonName"
+                            android:textColor="@color/black"
+                            android:textColorHint="@color/text_hint" />
+                    </com.google.android.material.textfield.TextInputLayout>
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="4dp"
-                        android:text="Email"
-                        android:textColor="@color/text_primary"
-                        android:textSize="14sp" />
-
-                    <EditText
-                        android:id="@+id/editTextEmail"
+                    <com.google.android.material.textfield.TextInputLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginBottom="16dp"
-                        android:hint="Introduzca el email"
-                        android:inputType="textEmailAddress" />
+                        android:layout_marginBottom="12dp"
+                        app:boxBackgroundColor="@color/white"
+                        app:boxStrokeColor="@color/green_primary">
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/editTextEmail"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:hint="Email"
+                            android:inputType="textEmailAddress"
+                            android:textColor="@color/black"
+                            android:textColorHint="@color/text_hint" />
+                    </com.google.android.material.textfield.TextInputLayout>
 
-                    <TextView
+                    <com.google.android.material.textfield.TextInputLayout
                         android:id="@+id/labelPassword"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="4dp"
-                        android:text="Contraseña"
-                        android:textColor="@color/text_primary"
-                        android:textSize="14sp" />
-
-                    <EditText
-                        android:id="@+id/editTextPassword"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginBottom="16dp"
-                        android:hint="Introduzca la contraseña"
-                        android:inputType="textPassword" />
+                        android:layout_marginBottom="12dp"
+                        app:boxBackgroundColor="@color/white"
+                        app:boxStrokeColor="@color/green_primary"
+                        app:passwordToggleEnabled="true">
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/editTextPassword"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:hint="Contraseña"
+                            android:inputType="textPassword"
+                            android:textColor="@color/black"
+                            android:textColorHint="@color/text_hint" />
+                    </com.google.android.material.textfield.TextInputLayout>
 
                     <LinearLayout
                         android:layout_width="match_parent"


### PR DESCRIPTION
## Summary

- Replace plain `EditText` with `TextInputLayout` + `TextInputEditText` in all form fragments (`fragment_formulario_centro`, `fragment_formulario_dispositivo`, `fragment_formulario_usuario`)
- Fix `labelPassword` field type from `TextView` to `View` in `FormularioUsuarioFragment` to avoid ClassCastException
- Add password toggle to password field in `fragment_formulario_usuario`
- Add missing `Cancelar` button to `fragment_crear_arbol` for consistency with other forms
- Rename primary button text from "Crear Árbol" to "Guardar" in `fragment_crear_arbol`

Closes #272

## Test plan

- [x] Abrir formulario de Centro: verificar que los campos muestran hint flotante y borde verde al enfocar
- [x] Abrir formulario de Dispositivo: verificar campos de datos básicos y umbrales
- [x] Abrir formulario de Usuario: verificar hint flotante, toggle de contraseña visible, y que el campo contraseña se oculta al editar
- [x] Abrir formulario de Crear Árbol: verificar botones Guardar y Cancelar en la barra superior
- [x] Comprobar que la validación inline (`setError`) sigue funcionando en todos los formularios