### PR TITLE
fix(frontend): resolve all ESLint errors

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'coverage']),
   {
     files: ['**/*.{js,jsx}'],
     extends: [
@@ -24,6 +24,12 @@ export default defineConfig([
     },
     rules: {
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+    },
+  },
+  {
+    files: ['src/tests/**/*.{js,jsx}', '**/*.test.{js,jsx}', '**/*.spec.{js,jsx}'],
+    languageOptions: {
+      globals: globals.jest,
     },
   },
 ])

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -3,6 +3,7 @@ import api from "../services/api";
 
 const AuthContext = createContext();
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const useAuth = () => {
     const context = useContext(AuthContext);
     if (!context) {
@@ -20,6 +21,7 @@ export const AuthProvider = ({ children }) => {
         const storedUser = localStorage.getItem('user');
         if (storedUser) {
             try {
+                // eslint-disable-next-line react-hooks/set-state-in-effect
                 setUser(JSON.parse(storedUser));
             } catch (error) {
                 console.error('Error parsing user from localStorage:', error);

--- a/frontend/src/pages/component-library/ComponentLibrary.jsx
+++ b/frontend/src/pages/component-library/ComponentLibrary.jsx
@@ -5,6 +5,12 @@ import Input from "../../components/common/Input";
 import Alert from "../../components/common/Alert";
 import Spinner from "../../components/common/Spinner";
 
+const CodeBlock = ({ code }) => (
+  <pre className="bg-gray-800 text-gray-100 p-4 rounded-md overflow-x-auto text-sm">
+    <code>{code}</code>
+  </pre>
+);
+
 const ComponentLibrary = () => {
   const [inputValue, setInputValue] = useState("");
   const [showSuccessAlert, setShowSuccessAlert] = useState(true);
@@ -14,12 +20,6 @@ const ComponentLibrary = () => {
     setLoading(true);
     setTimeout(() => setLoading(false), 2000);
   };
-
-  const CodeBlock = ({ code }) => (
-    <pre className="bg-gray-800 text-gray-100 p-4 rounded-md overflow-x-auto text-sm">
-      <code>{code}</code>
-    </pre>
-  );
 
   return (
     <div className="max-w-6xl mx-auto">

--- a/frontend/src/tests/lecturasService.test.js
+++ b/frontend/src/tests/lecturasService.test.js
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 import api from '../services/api';
-import { getUltimaLectura, getLecturasParaGrafica } from '../services/lecturasService';
+import { getUltimaLectura } from '../services/lecturasService';
 
 vi.mock('../services/api');
 


### PR DESCRIPTION
## Summary

- Add vitest globals (`jest` env) to ESLint config for test files — fixes ~60 `no-undef` errors on `describe`, `it`, `expect`, etc.
- Exclude `coverage/` directory from linting
- Move `CodeBlock` component outside `ComponentLibrary` to fix `static-components` rule (12 errors)
- Add `eslint-disable-next-line` for two intentional patterns in `AuthContext.jsx`
- Remove unused `getLecturasParaGrafica` import in `lecturasService.test.js`

Result: `npm run lint` goes from **81 errors** to **0 errors** (7 warnings remain, all `exhaustive-deps`, non-blocking).

## Test plan

- [x] `npm run lint` returns 0 errors
- [x] `npm test` — all 21 tests still passing