### PR TITLE
feat(frontend): JWT token persistence in localStorage

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -21,11 +21,14 @@ export const AuthProvider = ({ children }) => {
         const storedUser = localStorage.getItem('user');
         if (storedUser) {
             try {
+                const parsed = JSON.parse(storedUser);
                 // eslint-disable-next-line react-hooks/set-state-in-effect
-                setUser(JSON.parse(storedUser));
+                setUser(parsed);
+                if (parsed.token) localStorage.setItem('token', parsed.token);
             } catch (error) {
                 console.error('Error parsing user from localStorage:', error);
                 localStorage.removeItem('user');
+                localStorage.removeItem('token');
             }
         }
         setLoading(false);
@@ -40,6 +43,7 @@ export const AuthProvider = ({ children }) => {
             const response = await api.post('/auth/login', { email, password });
             const userData = response.data;
             localStorage.setItem('user', JSON.stringify(userData));
+            localStorage.setItem('token', userData.token);
             setUser(userData);
             return userData;
         } catch (error) {
@@ -53,9 +57,9 @@ export const AuthProvider = ({ children }) => {
         }
     };
 
-    // Logout - elimina usuario del localStorage
     const logout = () => {
         localStorage.removeItem('user');
+        localStorage.removeItem('token');
         setUser(null);
     };
 
@@ -68,6 +72,7 @@ export const AuthProvider = ({ children }) => {
             const response = await api.post('/auth/register', { nombre, email, password });
             const userData = response.data;
             localStorage.setItem('user', JSON.stringify(userData));
+            localStorage.setItem('token', userData.token);
             setUser(userData);
             return userData;
         } catch (error) {


### PR DESCRIPTION
## Summary

- Save JWT token to `localStorage` under key `'token'` on login and register
- Restore token from stored user object on page reload
- Clear token from `localStorage` on logout
- The existing axios interceptor in `api.js` already reads from `'token'` and adds `Authorization: Bearer` header to every request

## Test plan

- [x] Login → LocalStorage shows both `user` and `token` keys
- [x] Page reload → token is restored, protected routes still work
- [x] Create/edit operations succeed (token sent in Authorization header)
- [x] Logout → both `user` and `token` keys removed from LocalStorage