### PR TITLE
feat(android): JWT authentication with OkHttp interceptor

### DIFF
--- a/android/app/src/main/java/com/example/proyectoarboles/activities/MainActivity.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/activities/MainActivity.java
@@ -22,6 +22,7 @@ import com.example.proyectoarboles.fragments.ListarCentrosFragment;
 import com.example.proyectoarboles.fragments.LoginFragment;
 import com.example.proyectoarboles.fragments.RegistrerFragment;
 import com.example.proyectoarboles.model.Usuario;
+import com.example.proyectoarboles.api.RetrofitClient;
 import com.example.proyectoarboles.util.PermissionManager;
 import com.google.android.material.navigation.NavigationBarView;
 import com.google.android.material.navigationrail.NavigationRailView;
@@ -37,6 +38,7 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
+        RetrofitClient.init(this);
         permissionManager = new PermissionManager(this);
 
         NavigationRailView rail = findViewById(R.id.navigation_rail);

--- a/android/app/src/main/java/com/example/proyectoarboles/api/AuthInterceptor.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/api/AuthInterceptor.java
@@ -1,4 +1,7 @@
-/*package com.example.proyectoarboles.api;
+package com.example.proyectoarboles.api;
+
+import android.content.Context;
+import android.content.SharedPreferences;
 
 import java.io.IOException;
 
@@ -7,27 +10,25 @@ import okhttp3.Request;
 import okhttp3.Response;
 
 public class AuthInterceptor implements Interceptor {
+
+    private final SharedPreferences sharedPreferences;
+
+    public AuthInterceptor(Context context) {
+        this.sharedPreferences = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE);
+    }
+
     @Override
     public Response intercept(Chain chain) throws IOException {
+        String token = sharedPreferences.getString("token", null);
         Request original = chain.request();
-
-        // Obtener token de SharedPreferences
-        // (Necesita contexto, se puede pasar en constructor)
-        String token = getTokenFromPreferences();
 
         if (token != null) {
             Request request = original.newBuilder()
-                .header("Authorization", "Bearer " + token)
-                .build();
+                    .header("Authorization", "Bearer " + token)
+                    .build();
             return chain.proceed(request);
         }
 
         return chain.proceed(original);
     }
-
-    private String getTokenFromPreferences() {
-        // Implementar acceso a SharedPreferences
-        return null; // Placeholder
-    }
 }
-*/

--- a/android/app/src/main/java/com/example/proyectoarboles/api/RetrofitClient.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/api/RetrofitClient.java
@@ -1,5 +1,7 @@
 package com.example.proyectoarboles.api;
 
+import android.content.Context;
+
 import com.example.proyectoarboles.BuildConfig;
 import com.example.proyectoarboles.adapter.BigDecimalStringAdapter;
 import com.google.gson.Gson;
@@ -25,14 +27,44 @@ public class RetrofitClient {
     private static LecturaApi lecturaApi = null;
     private static DispositivoApi dispositivoApi = null;
 
+    public static void init(Context context) {
+        AuthInterceptor authInterceptor = new AuthInterceptor(context.getApplicationContext());
+
+        OkHttpClient okHttpClient = new OkHttpClient.Builder()
+                .addInterceptor(authInterceptor)
+                .connectTimeout(60, TimeUnit.SECONDS)
+                .readTimeout(60, TimeUnit.SECONDS)
+                .writeTimeout(60, TimeUnit.SECONDS)
+                .build();
+
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapter(String.class, new BigDecimalStringAdapter())
+                .setLenient()
+                .create();
+
+        retrofit = new Retrofit.Builder()
+                .baseUrl(BASE_URL)
+                .client(okHttpClient)
+                .addConverterFactory(GsonConverterFactory.create(gson))
+                .build();
+
+        arbolApi = null;
+        centroEducativoApi = null;
+        authApi = null;
+        usuarioApi = null;
+        usuarioCentroApi = null;
+        lecturaApi = null;
+        dispositivoApi = null;
+    }
+
     public static Retrofit getRetrofitInstance() {
         if (retrofit == null) {
 
-            // OKHTTP CLIENT CON TIMEOUT
+            // OKHTTP CLIENT CON TIMEOUT (sin AuthInterceptor — usar init(context) en su lugar)
             OkHttpClient okHttpClient = new OkHttpClient.Builder()
-                    .connectTimeout(60, TimeUnit.SECONDS)  // tiempo para conectar
-                    .readTimeout(60, TimeUnit.SECONDS)     // tiempo para recibir datos
-                    .writeTimeout(60, TimeUnit.SECONDS)    // tiempo para enviar datos
+                    .connectTimeout(60, TimeUnit.SECONDS)
+                    .readTimeout(60, TimeUnit.SECONDS)
+                    .writeTimeout(60, TimeUnit.SECONDS)
                     .build();
 
             // CONFIGURAR GSON

--- a/android/app/src/main/java/com/example/proyectoarboles/dto/AuthResponse.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/dto/AuthResponse.java
@@ -20,6 +20,9 @@ public class AuthResponse {
     @SerializedName("centros")
     private List<CentroRef> centros;
 
+    @SerializedName("token")
+    private String token;
+
     // Getters
     public Long getId() {
         return id;
@@ -39,6 +42,10 @@ public class AuthResponse {
 
     public List<CentroRef> getCentros() {
         return centros;
+    }
+
+    public String getToken() {
+        return token;
     }
 
     /**

--- a/android/app/src/main/java/com/example/proyectoarboles/fragments/LoginFragment.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/fragments/LoginFragment.java
@@ -119,6 +119,7 @@ public class LoginFragment extends Fragment {
         editor.putLong("user_id", authResponse.getId());
         editor.putString("user_name", authResponse.getNombre());
         editor.putString("user_email", authResponse.getEmail());
+        editor.putString("token", authResponse.getToken());
 
         if (authResponse.getRol() != null) {
             editor.putString("user_role", authResponse.getRol());

--- a/android/app/src/main/java/com/example/proyectoarboles/fragments/RegistrerFragment.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/fragments/RegistrerFragment.java
@@ -131,6 +131,7 @@ public class RegistrerFragment extends Fragment {
         editor.putLong("user_id", authResponse.getId());
         editor.putString("user_name", authResponse.getNombre());
         editor.putString("user_email", authResponse.getEmail());
+        editor.putString("token", authResponse.getToken());
 
         if (authResponse.getRol() != null) {
             editor.putString("user_role", authResponse.getRol());


### PR DESCRIPTION
## Summary

- Add `token` field to Android `AuthResponse` DTO
- Implement `AuthInterceptor` with OkHttp sending `Authorization: Bearer` on every request
- Add `RetrofitClient.init(Context)` initialized from `MainActivity.onCreate()`
- Save JWT token to SharedPreferences on login and register
- Token cleared automatically on logout via `PermissionManager.clearSession()`

## Test plan

- [x] Login → data loads correctly
- [x] Create/edit operations succeed with valid token
- [x] Admin sees user administration section
- [x] Coordinador does not see admin-only sections
- [x] Logout → session and token cleared