### PR TITLE
feat(frontend): remove Arboles menu and update dashboard/footer design

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,7 +5,6 @@ import Login from './pages/login/Login';
 import Register from './pages/register/Register';
 import Dashboard from './pages/dashboard/Dashboard';
 import ComponentLibrary from './pages/component-library/ComponentLibrary';
-import ListadoArboles from './pages/arboles/ListadoArboles';
 import DetalleArbol from './pages/arboles/DetalleArbol';
 import FormularioArbol from './pages/arboles/FormularioArbol';
 import ListadoCentros from './pages/centros/ListadoCentros';
@@ -36,7 +35,6 @@ function App() {
         {/* Rutas públicas de lectura con layout */}
         <Route element={<MainLayout />}>
           <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/arboles" element={<ListadoArboles />} />
           <Route path="/arboles/:id" element={<DetalleArbol />} />
           <Route path="/dispositivos/:id/lecturas" element={<HistoricoDispositivo />} />
           <Route path="/centros" element={<ListadoCentros />} />

--- a/frontend/src/layout/Footer.jsx
+++ b/frontend/src/layout/Footer.jsx
@@ -22,10 +22,10 @@ const Footer = () => {
                 {/* Col 2 — Navegación + contacto */}
                 <div className="bg-brand-primary lg:w-4/12 flex flex-col justify-center px-10 py-6 gap-3 border-t lg:border-t-0 lg:border-l border-white/10 min-w-0">
                     <nav className="flex flex-row flex-wrap gap-x-5 gap-y-1">
-                        <a href="#" className="text-sm text-brand-accent hover:text-brand-bg-green tracking-wide font-semibold transition">El proyecto</a>
-                        <a href="#" className="text-sm text-brand-accent hover:text-brand-bg-green tracking-wide font-semibold transition">Plantaciones</a>
-                        <a href="#" className="text-sm text-brand-accent hover:text-brand-bg-green tracking-wide font-semibold transition">Actualidad</a>
-                        <a href="#" className="text-sm text-brand-accent hover:text-brand-bg-green tracking-wide font-semibold transition">Contacto</a>
+                        <a href="https://proyectoarboles.org" target="proyecto-arboles" className="text-sm text-brand-accent hover:text-brand-bg-green tracking-wide font-semibold transition">El proyecto</a>
+                        <a href="https://proyectoarboles.org/#plantaciones" target="proyecto-arboles" className="text-sm text-brand-accent hover:text-brand-bg-green tracking-wide font-semibold transition">Plantaciones</a>
+                        <a href="https://proyectoarboles.org/#actualidad" target="proyecto-arboles" className="text-sm text-brand-accent hover:text-brand-bg-green tracking-wide font-semibold transition">Actualidad</a>
+                        <a href="https://proyectoarboles.org/#contacto" target="proyecto-arboles" className="text-sm text-brand-accent hover:text-brand-bg-green tracking-wide font-semibold transition">Contacto</a>
                     </nav>
                     <div className="flex flex-wrap items-center gap-4">
                         <a href="tel:+34667894205" className="text-sm text-white/70 hover:text-brand-accent transition">

--- a/frontend/src/layout/Header.jsx
+++ b/frontend/src/layout/Header.jsx
@@ -48,9 +48,6 @@ const Header = () => {
                         <NavLink to="/dashboard" className={navLinkClass}>
                             Dashboard
                         </NavLink>
-                        <NavLink to="/arboles" className={navLinkClass}>
-                            Árboles
-                        </NavLink>
                         <NavLink to="/centros" className={navLinkClass}>
                             Centros
                         </NavLink>
@@ -132,13 +129,6 @@ const Header = () => {
                                 className={({ isActive }) => `${navLinkClass({ isActive })} py-2`}
                             >
                                 Dashboard
-                            </NavLink>
-                            <NavLink
-                                to="/arboles"
-                                onClick={closeMobileMenu}
-                                className={({ isActive }) => `${navLinkClass({ isActive })} py-2`}
-                            >
-                                Árboles
                             </NavLink>
                             <NavLink
                                 to="/centros"

--- a/frontend/src/pages/dashboard/Dashboard.jsx
+++ b/frontend/src/pages/dashboard/Dashboard.jsx
@@ -1,9 +1,19 @@
 import { Link } from "react-router-dom";
+import { useState, useEffect } from "react";
 import { useAuth } from "../../context/AuthContext";
-import { TreePine, School } from "lucide-react";
+import { School, TreePine } from "lucide-react";
+import { getCentros } from "../../services/centrosService";
+import { getArboles } from "../../services/arbolesService";
 
 const Dashboard = () => {
   const { user } = useAuth();
+  const [numCentros, setNumCentros] = useState(null);
+  const [numArboles, setNumArboles] = useState(null);
+
+  useEffect(() => {
+    getCentros().then(data => setNumCentros(data.length)).catch(() => setNumCentros('—'));
+    getArboles().then(data => setNumArboles(data.length)).catch(() => setNumArboles('—'));
+  }, []);
 
   return (
     <div className="max-w-4xl mx-auto">
@@ -19,24 +29,30 @@ const Dashboard = () => {
         </p>
       </div>
 
-      {/* Tarjetas de acceso rápido */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {/* Tarjeta Árboles */}
-        <Link
-          to="/arboles"
-          className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition group"
-        >
-          <div className="flex items-center mb-4">
-            <TreePine className="w-10 h-10 mr-4 text-brand-secondary shrink-0" />
-            <h2 className="text-2xl font-bold text-brand-primary transition">
-              Árboles
-            </h2>
+      {/* Métricas */}
+      <div className="bg-brand-primary rounded-lg shadow-md px-8 py-5 mb-6 flex divide-x divide-white/20">
+        <div className="flex items-center gap-3 pr-8">
+          <School className="w-7 h-7 text-brand-bg-green shrink-0" />
+          <div>
+            <p className="text-2xl font-bold text-white leading-none">
+              {numCentros ?? '…'}
+            </p>
+            <p className="text-xs text-white/60 mt-1">Centros educativos</p>
           </div>
-          <p className="text-brand-text">
-            Consulta, añade y gestiona los árboles monitorizados en los diferentes centros educativos.
-          </p>
-        </Link>
+        </div>
+        <div className="flex items-center gap-3 pl-8">
+          <TreePine className="w-7 h-7 text-brand-bg-green shrink-0" />
+          <div>
+            <p className="text-2xl font-bold text-white leading-none">
+              {numArboles ?? '…'}
+            </p>
+            <p className="text-xs text-white/60 mt-1">Árboles plantados</p>
+          </div>
+        </div>
+      </div>
 
+      {/* Tarjetas de acceso rápido */}
+      <div className="grid grid-cols-1 gap-6">
         {/* Tarjeta Centros */}
         <Link
           to="/centros"


### PR DESCRIPTION
## Summary
- Remove Árboles nav link from Header (desktop and mobile menus)
- Remove `/arboles` list route from App.jsx (detail and form routes kept)
- Replace dashboard Árboles card with a stats metrics bar showing total centros and total árboles
- Update Footer links to real proyectoarboles.org URLs (El proyecto, Plantaciones, Actualidad, Contacto) with named target for tab reuse

## Test plan
- [x] Verify Árboles link no longer appears in desktop nav or mobile menu
- [x] Verify `/centros` and `/dashboard` routes still work
- [x] Verify dashboard metrics bar loads centros and arboles counts
- [x] Verify Footer links open proyectoarboles.org in a named tab
- [x] Verify `/arboles/:id` detail page still accessible (e.g. from a centros detail page)