### PR TITLE
feat: add cantidad field to Arbol across all layers

### DIFF
--- a/android/app/src/main/java/com/example/proyectoarboles/fragments/ArbolDetallesFragment.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/fragments/ArbolDetallesFragment.java
@@ -47,11 +47,11 @@ public class ArbolDetallesFragment extends Fragment {
     private static final String TAG = "ArbolDetallesFragment";
     private static final String ARG_ARBOL_ID = "arbol_id";
 
-    private TextView tvNombre, tvEspecie, tvFecha, tvUbicacion, tvCentroEducativo, tvAbsorcionCo2;
-    private TextInputEditText etNombre, etEspecie, etFecha, etUbicacion;
-    private TextInputLayout tilNombre, tilEspecie, tilFecha, tilUbicacion;
+    private TextView tvNombre, tvEspecie, tvFecha, tvUbicacion, tvCentroEducativo, tvAbsorcionCo2, tvCantidad;
+    private TextInputEditText etNombre, etEspecie, etFecha, etUbicacion, etCantidad;
+    private TextInputLayout tilNombre, tilEspecie, tilFecha, tilUbicacion, tilCantidad;
     private Spinner spinnerCentroEducativo;
-    private LinearLayout llNombreView, llEspecieView, llFechaView, llCentroView, llUbicacionView;
+    private LinearLayout llNombreView, llEspecieView, llFechaView, llCentroView, llUbicacionView, llCantidadView;
     private ImageButton btnEditar, btnEliminar, btnVolver;
     private Button btnGuardar, btnCancelar;
 
@@ -121,10 +121,12 @@ public class ArbolDetallesFragment extends Fragment {
         etEspecie = view.findViewById(R.id.editTextEspecieDetalle);
         etFecha = view.findViewById(R.id.editTextFechaDetalle);
         etUbicacion = view.findViewById(R.id.editTextUbicacion);
+        etCantidad = view.findViewById(R.id.editTextCantidad);
         tilNombre = view.findViewById(R.id.tilNombreDetalle);
         tilEspecie = view.findViewById(R.id.tilEspecieDetalle);
         tilFecha = view.findViewById(R.id.tilFechaDetalle);
         tilUbicacion = view.findViewById(R.id.tilUbicacion);
+        tilCantidad = view.findViewById(R.id.tilCantidad);
 
         spinnerCentroEducativo = view.findViewById(R.id.spinnerCentroEducativo);
         centrosAdapter = new ArrayAdapter<>(requireContext(), android.R.layout.simple_spinner_item, listaCentros);
@@ -136,6 +138,8 @@ public class ArbolDetallesFragment extends Fragment {
         llFechaView = view.findViewById(R.id.llFechaView);
         llCentroView = view.findViewById(R.id.llCentroView);
         llUbicacionView = view.findViewById(R.id.llUbicacionView);
+        llCantidadView = view.findViewById(R.id.llCantidadView);
+        tvCantidad = view.findViewById(R.id.textViewCantidad);
 
         btnEditar = view.findViewById(R.id.buttonEditar);
         btnGuardar = view.findViewById(R.id.buttonGuardar);
@@ -184,6 +188,7 @@ public class ArbolDetallesFragment extends Fragment {
         tvUbicacion.setText(arbol.getUbicacion() != null ? arbol.getUbicacion() : "No disponible");
         tvCentroEducativo.setText(arbol.getCentroEducativo() != null
                 ? arbol.getCentroEducativo().getNombre() : "Sin centro asignado");
+        tvCantidad.setText(String.valueOf(arbol.getCantidad()));
         if (arbol.getAbsorcionCo2Anual() != null) {
             tvAbsorcionCo2.setText(String.format(Locale.getDefault(), "%.2f kg/año", arbol.getAbsorcionCo2Anual()));
         } else {
@@ -208,12 +213,23 @@ public class ArbolDetallesFragment extends Fragment {
         String especie = etEspecie.getText().toString().trim();
         String fecha = etFecha.getText().toString().trim();
         String ubicacion = etUbicacion.getText().toString().trim();
+        String cantidadStr = etCantidad.getText() != null ? etCantidad.getText().toString().trim() : "1";
 
         if (nombre.isEmpty()) { etNombre.setError("El nombre es requerido"); return; }
         if (especie.isEmpty()) { etEspecie.setError("La especie es requerida"); return; }
         if (fecha.isEmpty()) { etFecha.setError("La fecha es requerida"); return; }
         if (!validarFecha(fecha)) {
             etFecha.setError("Fecha inválida. Usa formato YYYY-MM-DD y debe ser en el pasado");
+            return;
+        }
+
+        int cantidad;
+        try {
+            cantidad = Integer.parseInt(cantidadStr);
+            if (cantidad < 1) throw new NumberFormatException();
+        } catch (NumberFormatException e) {
+            etCantidad.setError("La cantidad debe ser al menos 1");
+            etCantidad.requestFocus();
             return;
         }
 
@@ -230,6 +246,7 @@ public class ArbolDetallesFragment extends Fragment {
         arbolActualizado.setFechaPlantacion(fecha);
         arbolActualizado.setUbicacion(ubicacion);
         arbolActualizado.setCentroEducativo(centroSeleccionado);
+        arbolActualizado.setCantidad(cantidad);
 
         actualizarArbolEnAPI(arbolActual.getId(), arbolActualizado);
     }
@@ -261,6 +278,8 @@ public class ArbolDetallesFragment extends Fragment {
         tilUbicacion.setVisibility(View.GONE);
         llCentroView.setVisibility(View.VISIBLE);
         spinnerCentroEducativo.setVisibility(View.GONE);
+        llCantidadView.setVisibility(View.VISIBLE);
+        tilCantidad.setVisibility(View.GONE);
         btnGuardar.setVisibility(View.GONE);
         btnCancelar.setVisibility(View.GONE);
         verificarPermisosYActualizarUI();
@@ -281,6 +300,9 @@ public class ArbolDetallesFragment extends Fragment {
         etUbicacion.setText(tvUbicacion.getText());
         llCentroView.setVisibility(View.GONE);
         spinnerCentroEducativo.setVisibility(View.VISIBLE);
+        llCantidadView.setVisibility(View.GONE);
+        tilCantidad.setVisibility(View.VISIBLE);
+        if (arbolActual != null) etCantidad.setText(String.valueOf(arbolActual.getCantidad()));
         btnEditar.setVisibility(View.GONE);
         btnEliminar.setVisibility(View.GONE);
         btnGuardar.setVisibility(View.VISIBLE);

--- a/android/app/src/main/java/com/example/proyectoarboles/fragments/CrearArbolFragment.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/fragments/CrearArbolFragment.java
@@ -38,6 +38,7 @@ public class CrearArbolFragment extends Fragment {
     private TextInputEditText inputEspecie;
     private TextInputEditText inputFechaPlantacion;
     private TextInputEditText inputUbicacion;
+    private TextInputEditText inputCantidad;
     private Button btnCrear;
     private Button btnCancelar;
     private ImageButton btnVolver;
@@ -73,6 +74,7 @@ public class CrearArbolFragment extends Fragment {
         inputEspecie = view.findViewById(R.id.inputEspecieArbol);
         inputFechaPlantacion = view.findViewById(R.id.inputFechaPlantacion);
         inputUbicacion = view.findViewById(R.id.inputUbicacion);
+        inputCantidad = view.findViewById(R.id.inputCantidad);
         btnCrear = view.findViewById(R.id.btnCrearArbol);
         btnCancelar = view.findViewById(R.id.btnCancelarCrearArbol);
         btnVolver = view.findViewById(R.id.buttonVolverCrearArbol);
@@ -96,6 +98,7 @@ public class CrearArbolFragment extends Fragment {
         String especie = inputEspecie.getText() != null ? inputEspecie.getText().toString().trim() : "";
         String fechaStr = inputFechaPlantacion.getText() != null ? inputFechaPlantacion.getText().toString().trim() : "";
         String ubicacion = inputUbicacion.getText() != null ? inputUbicacion.getText().toString().trim() : "";
+        String cantidadStr = inputCantidad.getText() != null ? inputCantidad.getText().toString().trim() : "1";
 
         if (nombre.isEmpty()) {
             inputNombre.setError("El nombre es requerido");
@@ -121,7 +124,17 @@ public class CrearArbolFragment extends Fragment {
             return;
         }
 
-        crearArbol(nombre, especie, fechaStr, ubicacion);
+        int cantidad;
+        try {
+            cantidad = Integer.parseInt(cantidadStr);
+            if (cantidad < 1) throw new NumberFormatException();
+        } catch (NumberFormatException e) {
+            inputCantidad.setError("La cantidad debe ser al menos 1");
+            inputCantidad.requestFocus();
+            return;
+        }
+
+        crearArbol(nombre, especie, fechaStr, ubicacion, cantidad);
     }
 
     private boolean validarFecha(String fechaStr) {
@@ -136,7 +149,7 @@ public class CrearArbolFragment extends Fragment {
         }
     }
 
-    private void crearArbol(String nombre, String especie, String fechaPlantacion, String ubicacion) {
+    private void crearArbol(String nombre, String especie, String fechaPlantacion, String ubicacion, int cantidad) {
         progressBar.setVisibility(View.VISIBLE);
         btnCrear.setEnabled(false);
 
@@ -150,6 +163,7 @@ public class CrearArbolFragment extends Fragment {
         nuevoArbol.setFechaPlantacion(fechaPlantacion);
         nuevoArbol.setUbicacion(ubicacion);
         nuevoArbol.setCentroEducativo(centro);
+        nuevoArbol.setCantidad(cantidad);
 
         Call<Arbol> call = RetrofitClient.getArbolApi().crearArbol(nuevoArbol);
         call.enqueue(new Callback<Arbol>() {

--- a/android/app/src/main/java/com/example/proyectoarboles/fragments/DashboardFragment.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/fragments/DashboardFragment.java
@@ -90,7 +90,11 @@ public class DashboardFragment extends Fragment {
             public void onResponse(Call<List<Arbol>> call, Response<List<Arbol>> response) {
                 if (!isAdded()) return;
                 if (response.isSuccessful() && response.body() != null) {
-                    tvNumeroArboles.setText(String.valueOf(response.body().size()));
+                    int total = 0;
+                    for (Arbol a : response.body()) {
+                        total += a.getCantidad();
+                    }
+                    tvNumeroArboles.setText(String.valueOf(total));
                 } else {
                     tvNumeroArboles.setText("Error");
                 }

--- a/android/app/src/main/java/com/example/proyectoarboles/fragments/DetalleCentroFragment.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/fragments/DetalleCentroFragment.java
@@ -288,10 +288,12 @@ public class DetalleCentroFragment extends Fragment {
 
         TextView tvNombre = itemView.findViewById(R.id.textViewNombreArbolFila);
         TextView tvEspecie = itemView.findViewById(R.id.textViewEspecieArbolFila);
+        TextView tvCantidad = itemView.findViewById(R.id.textViewCantidadArbolFila);
         Button btnVer = itemView.findViewById(R.id.buttonVerArbol);
 
         tvNombre.setText(arbol.getNombre());
         tvEspecie.setText(arbol.getEspecie());
+        tvCantidad.setText("Cantidad: " + arbol.getCantidad());
         btnVer.setOnClickListener(v ->
                 ((MainActivity) requireActivity()).navigateToArbolDetalles(arbol.getId()));
 

--- a/android/app/src/main/java/com/example/proyectoarboles/model/Arbol.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/model/Arbol.java
@@ -25,6 +25,9 @@ public class Arbol {
     @SerializedName("absorcionCo2Anual")
     private Double absorcionCo2Anual;
 
+    @SerializedName("cantidad")
+    private Integer cantidad;
+
     // Constructor básico (para XML/fallback)
     public Arbol(Long id, String nombre, String especie, String fechaPlantacion){
         this.id = id;
@@ -65,6 +68,10 @@ public class Arbol {
         return absorcionCo2Anual;
     }
 
+    public Integer getCantidad() {
+        return cantidad != null ? cantidad : 1;
+    }
+
     // Setters
     public void setId(Long id) {
         this.id = id;
@@ -92,6 +99,10 @@ public class Arbol {
 
     public void setAbsorcionCo2Anual(Double absorcionCo2Anual) {
         this.absorcionCo2Anual = absorcionCo2Anual;
+    }
+
+    public void setCantidad(Integer cantidad) {
+        this.cantidad = cantidad;
     }
 
     @Override

--- a/android/app/src/main/res/layout/fragment_arbol_detalles.xml
+++ b/android/app/src/main/res/layout/fragment_arbol_detalles.xml
@@ -307,6 +307,47 @@
                         android:textColorHint="@color/text_hint"/>
                 </com.google.android.material.textfield.TextInputLayout>
 
+                <!-- Cantidad -->
+                <LinearLayout
+                    android:id="@+id/llCantidadView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:layout_marginBottom="8dp">
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Cantidad: "
+                        android:textSize="14sp"
+                        android:textStyle="bold"
+                        android:textColor="@color/text_primary"/>
+                    <TextView
+                        android:id="@+id/textViewCantidad"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:textSize="14sp"
+                        android:textColor="@color/text_secondary"/>
+                </LinearLayout>
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilCantidad"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:visibility="gone"
+                    app:boxBackgroundColor="@color/white"
+                    app:boxStrokeColor="@color/green_primary">
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/editTextCantidad"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="Cantidad de árboles"
+                        android:inputType="number"
+                        android:textColor="@color/black"
+                        android:textColorHint="@color/text_hint"/>
+                </com.google.android.material.textfield.TextInputLayout>
+
                 <!-- Absorción CO2 (solo lectura) -->
                 <LinearLayout
                     android:layout_width="match_parent"

--- a/android/app/src/main/res/layout/fragment_crear_arbol.xml
+++ b/android/app/src/main/res/layout/fragment_crear_arbol.xml
@@ -143,7 +143,7 @@
                 <com.google.android.material.textfield.TextInputLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="4dp"
+                    android:layout_marginBottom="12dp"
                     app:boxBackgroundColor="@color/white"
                     app:boxStrokeColor="@color/green_primary">
 
@@ -153,6 +153,25 @@
                         android:layout_height="wrap_content"
                         android:hint="Ubicación específica (opcional)"
                         android:inputType="text"
+                        android:textColor="@color/black"
+                        android:textColorHint="@color/text_hint" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="4dp"
+                    app:boxBackgroundColor="@color/white"
+                    app:boxStrokeColor="@color/green_primary">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/inputCantidad"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="Cantidad de árboles (mínimo 1)"
+                        android:inputType="number"
+                        android:text="1"
                         android:textColor="@color/black"
                         android:textColorHint="@color/text_hint" />
 

--- a/android/app/src/main/res/layout/item_arbol_fila.xml
+++ b/android/app/src/main/res/layout/item_arbol_fila.xml
@@ -28,6 +28,13 @@
             android:textSize="12sp"
             android:textColor="@color/text_secondary"/>
 
+        <TextView
+            android:id="@+id/textViewCantidadArbolFila"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="12sp"
+            android:textColor="@color/text_secondary"/>
+
     </LinearLayout>
 
     <Button

--- a/backend/create_database.sql
+++ b/backend/create_database.sql
@@ -86,7 +86,9 @@ CREATE TABLE arbol (
     ubicacion_especifica VARCHAR(200),
     -- Absorción de CO2 estimada al año (kg CO2/año)
     absorcion_co2_anual DECIMAL(8, 2),
+    cantidad INTEGER NOT NULL DEFAULT 1,
     CONSTRAINT pk_arbol PRIMARY KEY (id),
+    CONSTRAINT chk_arbol_cantidad CHECK (cantidad >= 1),
     CONSTRAINT fk_arbol_centro FOREIGN KEY (centro_id) REFERENCES centro_educativo(id) ON DELETE CASCADE
 );
 

--- a/backend/src/main/java/com/example/gardenmonitor/controller/ArbolController.java
+++ b/backend/src/main/java/com/example/gardenmonitor/controller/ArbolController.java
@@ -151,6 +151,7 @@ public class ArbolController {
         arbol.setFechaPlantacion(detallesArbol.getFechaPlantacion());
         arbol.setUbicacionEspecifica(detallesArbol.getUbicacionEspecifica());
         arbol.setAbsorcionCo2Anual(detallesArbol.getAbsorcionCo2Anual());
+        arbol.setCantidad(detallesArbol.getCantidad());
 
         return arbolRepository.save(arbol);
     }

--- a/backend/src/main/java/com/example/gardenmonitor/model/Arbol.java
+++ b/backend/src/main/java/com/example/gardenmonitor/model/Arbol.java
@@ -8,6 +8,7 @@ import org.hibernate.annotations.OnDeleteAction;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Past;
@@ -73,6 +74,11 @@ public class Arbol {
     @Column(name = "absorcion_co2_anual", columnDefinition = "DECIMAL(8,2)")
     @DecimalMin(value = "0")
     private BigDecimal absorcionCo2Anual;
+
+    @NotNull
+    @Min(1)
+    @Column(name = "cantidad", nullable = false, columnDefinition = "INTEGER DEFAULT 1")
+    private Integer cantidad = 1;
 
     /**
      * Constructor vacío requerido por JPA.
@@ -156,6 +162,14 @@ public class Arbol {
 
     public void setAbsorcionCo2Anual(BigDecimal absorcionCo2Anual) {
         this.absorcionCo2Anual = absorcionCo2Anual;
+    }
+
+    public Integer getCantidad() {
+        return cantidad;
+    }
+
+    public void setCantidad(Integer cantidad) {
+        this.cantidad = cantidad;
     }
 
     /**

--- a/docs/04. MODELO_DATOS.md
+++ b/docs/04. MODELO_DATOS.md
@@ -1,7 +1,7 @@
 # Modelo de Datos - Proyecto Árboles (Proyecto Árboles)
 
 **Fecha de creación**: 2025-11-15
-**Última actualización**: 2026-04-22
+**Última actualización**: 2026-05-04
 **Versión**: 2.0
 **Requisito**: AED - Acceso a Datos
 
@@ -92,6 +92,7 @@ erDiagram
         date fecha_plantacion
         string ubicacion_especifica
         decimal absorcion_co2_anual
+        int cantidad
     }
 
     DISPOSITIVO_ESP32 {
@@ -217,9 +218,11 @@ classDiagram
         -LocalDate fechaPlantacion
         -String ubicacionEspecifica
         -BigDecimal absorcionCo2Anual
+        -Integer cantidad
         +getId() Long
         +getEspecie() String
         +getCentro() CentroEducativo
+        +getCantidad() Integer
     }
 
     class DispositivoESP32 {
@@ -409,6 +412,7 @@ classDiagram
 | `fecha_plantacion` | DATE | NOT NULL | Fecha de plantación |
 | `ubicacion_especifica` | VARCHAR(200) | NULL | Ubicación dentro del centro |
 | `absorcion_co2_anual` | DECIMAL(8, 2) | NULL | Absorción CO2 estimada (kg/año) |
+| `cantidad` | INTEGER | NOT NULL, DEFAULT 1, CHECK >= 1 | Número de árboles de esta familia en el centro |
 
 **Índices**:
 - PRIMARY KEY en `id`
@@ -650,7 +654,9 @@ CREATE TABLE arbol (
     ubicacion_especifica VARCHAR(200),
     -- Absorción de CO2 estimada al año (kg CO2/año)
     absorcion_co2_anual DECIMAL(8, 2),
+    cantidad INTEGER NOT NULL DEFAULT 1,
     CONSTRAINT pk_arbol PRIMARY KEY (id),
+    CONSTRAINT chk_arbol_cantidad CHECK (cantidad >= 1),
     CONSTRAINT fk_arbol_centro FOREIGN KEY (centro_id) REFERENCES centro_educativo(id) ON DELETE CASCADE
 );
 
@@ -810,7 +816,7 @@ Además de las restricciones de base de datos, las entidades JPA incluirán:
 
 **Repositorio**: [github.com/riordi80/vocational-training-final-project](https://github.com/riordi80/vocational-training-final-project)
 
-**Última actualización**: 2026-04-22
+**Última actualización**: 2026-05-04
 
 ### Colaboradores
 

--- a/frontend/src/pages/arboles/DetalleArbol.jsx
+++ b/frontend/src/pages/arboles/DetalleArbol.jsx
@@ -43,9 +43,7 @@
       try {
         setDeleting(true);
         await deleteArbol(id);
-        navigate('/arboles', {
-          state: { message: 'Árbol eliminado correctamente' }
-        });
+        navigate(-1);
       } catch (err) {
         console.error('Error eliminando árbol:', err);
         setError('Error al eliminar el árbol. Por favor, intenta de nuevo.');
@@ -86,7 +84,7 @@
             onClose={() => setError('')}
           />
           <div className="mt-4">
-            <Button onClick={() => navigate('/arboles')}>Volver al listado</Button>
+            <Button onClick={() => navigate(-1)}>Volver</Button>
           </div>
         </div>
       );
@@ -100,7 +98,7 @@
             message="No se encontró el árbol solicitado."
           />
           <div className="mt-4">
-            <Button onClick={() => navigate('/arboles')}>Volver al listado</Button>
+            <Button onClick={() => navigate(-1)}>Volver</Button>
           </div>
         </div>
       );
@@ -171,6 +169,11 @@
               <div className="md:col-span-2">
                 <label className="block text-sm font-medium text-gray-600 mb-1">Ubicación Específica</label>
                 <p className="text-gray-900">{arbol.ubicacionEspecifica || 'No especificada'}</p>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-600 mb-1">Cantidad de árboles</label>
+                <p className="text-gray-900">{arbol.cantidad ?? 1}</p>
               </div>
 
               <div>

--- a/frontend/src/pages/arboles/FormularioArbol.jsx
+++ b/frontend/src/pages/arboles/FormularioArbol.jsx
@@ -23,7 +23,8 @@
       fechaPlantacion: '',
       ubicacionEspecifica: '',
       centroEducativo: { id: centroIdDesdeState || '' },
-      absorcionCo2Anual: ''
+      absorcionCo2Anual: '',
+      cantidad: 1
     });
 
     const [centros, setCentros] = useState([]);
@@ -64,7 +65,8 @@
             fechaPlantacion: fechaFormateada,
             ubicacionEspecifica: arbolData.ubicacionEspecifica || '',
             centroEducativo: { id: arbolData.centroEducativo?.id || '' },
-            absorcionCo2Anual: arbolData.absorcionCo2Anual || ''
+            absorcionCo2Anual: arbolData.absorcionCo2Anual || '',
+            cantidad: arbolData.cantidad ?? 1
           });
         }
       } catch (err) {
@@ -128,6 +130,11 @@
         nuevosErrores.centroEducativo = 'Debes seleccionar un centro educativo';
       }
 
+      const cantidadNum = parseInt(formData.cantidad);
+      if (!cantidadNum || cantidadNum < 1) {
+        nuevosErrores.cantidad = 'La cantidad debe ser al menos 1';
+      }
+
       // Validaciones de umbrales (si están presentes)
       setErrors(nuevosErrores);
       return Object.keys(nuevosErrores).length === 0;
@@ -152,7 +159,8 @@
           fechaPlantacion: formData.fechaPlantacion,
           ubicacionEspecifica: formData.ubicacionEspecifica.trim() || null,
           centroEducativo: { id: parseInt(formData.centroEducativo.id) },
-          absorcionCo2Anual: formData.absorcionCo2Anual !== '' ? parseFloat(formData.absorcionCo2Anual) : null
+          absorcionCo2Anual: formData.absorcionCo2Anual !== '' ? parseFloat(formData.absorcionCo2Anual) : null,
+          cantidad: parseInt(formData.cantidad) || 1
         };
 
         if (isEditMode) {
@@ -296,6 +304,25 @@
                     onChange={handleChange}
                     placeholder="Ej: Patio principal, junto a la entrada"
                   />
+                </div>
+
+                {/* Cantidad */}
+                <div>
+                  <Input
+                    id="cantidad"
+                    name="cantidad"
+                    label="Cantidad de árboles"
+                    type="number"
+                    min="1"
+                    value={formData.cantidad}
+                    onChange={handleChange}
+                    error={errors.cantidad}
+                    required
+                    placeholder="1"
+                  />
+                  <p className="text-xs text-gray-500 mt-1">
+                    Número de árboles de esta familia en el centro
+                  </p>
                 </div>
 
                 {/* Absorción CO2 Anual */}

--- a/frontend/src/pages/centros/DetalleCentro.jsx
+++ b/frontend/src/pages/centros/DetalleCentro.jsx
@@ -455,6 +455,9 @@ function DetalleCentro() {
                   <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
                     Ubicación
                   </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
+                    Cantidad
+                  </th>
                   <th className="px-6 py-3 text-right text-xs font-medium text-white uppercase tracking-wider">
                     Acciones
                   </th>
@@ -475,6 +478,9 @@ function DetalleCentro() {
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                       {arbol.ubicacionEspecifica || '-'}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {arbol.cantidad ?? 1}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-right">
                       <Button

--- a/frontend/src/pages/dashboard/Dashboard.jsx
+++ b/frontend/src/pages/dashboard/Dashboard.jsx
@@ -12,7 +12,7 @@ const Dashboard = () => {
 
   useEffect(() => {
     getCentros().then(data => setNumCentros(data.length)).catch(() => setNumCentros('—'));
-    getArboles().then(data => setNumArboles(data.length)).catch(() => setNumArboles('—'));
+    getArboles().then(data => setNumArboles(data.reduce((sum, a) => sum + (a.cantidad ?? 1), 0))).catch(() => setNumArboles('—'));
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- Add `cantidad` field (min 1, default 1) to `Arbol` entity in backend, frontend and Android
- Fix backend PUT handler which was missing `setCantidad` — caused updates to always save 1
- Dashboard metric now sums `cantidad` across all árboles instead of counting records
- Run DB migration on local and production: `ALTER TABLE arbol ADD COLUMN cantidad INTEGER DEFAULT 1 NOT NULL`

## Test plan
- [x] Create a new árbol with cantidad > 1, verify it saves correctly
- [x] Edit an existing árbol and change cantidad, verify it updates
- [x] Dashboard shows sum of cantidad (not count of records)
- [x] DetalleCentro table shows cantidad column for each árbol
- [x] Android: same checks with productionDebug variant after Render deploy