### PR TITLE
feat: add external action cards to dashboard

### DIFF
--- a/android/app/src/main/java/com/example/proyectoarboles/fragments/DashboardFragment.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/fragments/DashboardFragment.java
@@ -1,7 +1,9 @@
 package com.example.proyectoarboles.fragments;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
+import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -59,7 +61,7 @@ public class DashboardFragment extends Fragment {
         llEstadoUsuario = view.findViewById(R.id.llEstadoUsuario);
         btVerCentros = (MaterialCardView) view.findViewById(R.id.btVerCentros);
 
-        configurarListeners();
+        configurarListeners(view);
         actualizarInfoUsuario();
         cargarNumeroCentros();
         cargarNumeroArboles();
@@ -145,9 +147,17 @@ public class DashboardFragment extends Fragment {
         });
     }
 
-    private void configurarListeners() {
+    private void configurarListeners(View view) {
         btVerCentros.setOnClickListener(v ->
                 ((MainActivity) requireActivity()).navigateToListarCentros());
+
+        String urlContacto = "https://proyectoarboles.org/#contacto";
+        view.findViewById(R.id.btSumate).setOnClickListener(v -> abrirUrl(urlContacto));
+        view.findViewById(R.id.btApadrina).setOnClickListener(v -> abrirUrl(urlContacto));
+    }
+
+    private void abrirUrl(String url) {
+        startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
     }
 
     private void actualizarInfoUsuario() {

--- a/android/app/src/main/res/drawable/ic_heart.xml
+++ b/android/app/src/main/res/drawable/ic_heart.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:strokeColor="@color/green_secondary"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="@android:color/transparent"
+        android:pathData="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_users.xml
+++ b/android/app/src/main/res/drawable/ic_users.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:strokeColor="@color/green_secondary"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="@android:color/transparent"
+        android:pathData="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+    <path
+        android:strokeColor="@color/green_secondary"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="@android:color/transparent"
+        android:pathData="M5,7 a4,4,0,1,0,8,0 a4,4,0,1,0,-8,0" />
+    <path
+        android:strokeColor="@color/green_secondary"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="@android:color/transparent"
+        android:pathData="M22 21v-2a4 4 0 0 0-3-3.87" />
+    <path
+        android:strokeColor="@color/green_secondary"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="@android:color/transparent"
+        android:pathData="M16 3.13a4 4 0 0 1 0 7.75" />
+</vector>

--- a/android/app/src/main/res/layout/fragment_dashboard.xml
+++ b/android/app/src/main/res/layout/fragment_dashboard.xml
@@ -363,6 +363,110 @@
 
             </com.google.android.material.card.MaterialCardView>
 
+            <!-- Cards externas: Súmate + Apadrina -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginBottom="12dp">
+
+                <!-- Súmate al proyecto -->
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/btSumate"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:layout_marginEnd="6dp"
+                    android:clickable="true"
+                    android:focusable="true"
+                    app:cardBackgroundColor="@color/white"
+                    app:cardElevation="0dp"
+                    app:strokeColor="@color/gray_200"
+                    app:strokeWidth="1dp"
+                    app:cardCornerRadius="12dp"
+                    app:rippleColor="@color/green_secondary">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:padding="16dp">
+
+                        <ImageView
+                            android:layout_width="28dp"
+                            android:layout_height="28dp"
+                            android:src="@drawable/ic_users"
+                            android:layout_marginBottom="8dp" />
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="Súmate"
+                            android:textSize="15sp"
+                            android:textStyle="bold"
+                            android:textColor="@color/green_primary" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Solicita la plantación de árboles en tu centro educativo."
+                            android:textSize="12sp"
+                            android:textColor="@color/text_secondary"
+                            android:layout_marginTop="4dp" />
+
+                    </LinearLayout>
+
+                </com.google.android.material.card.MaterialCardView>
+
+                <!-- Apadrina un árbol -->
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/btApadrina"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:layout_marginStart="6dp"
+                    android:clickable="true"
+                    android:focusable="true"
+                    app:cardBackgroundColor="@color/white"
+                    app:cardElevation="0dp"
+                    app:strokeColor="@color/gray_200"
+                    app:strokeWidth="1dp"
+                    app:cardCornerRadius="12dp"
+                    app:rippleColor="@color/green_secondary">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:padding="16dp">
+
+                        <ImageView
+                            android:layout_width="28dp"
+                            android:layout_height="28dp"
+                            android:src="@drawable/ic_heart"
+                            android:layout_marginBottom="8dp" />
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="Apadrina"
+                            android:textSize="15sp"
+                            android:textStyle="bold"
+                            android:textColor="@color/green_primary" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Contribuye con un árbol y deja un legado verde."
+                            android:textSize="12sp"
+                            android:textColor="@color/text_secondary"
+                            android:layout_marginTop="4dp" />
+
+                    </LinearLayout>
+
+                </com.google.android.material.card.MaterialCardView>
+
+            </LinearLayout>
 
         </LinearLayout>
 

--- a/frontend/src/pages/dashboard/Dashboard.jsx
+++ b/frontend/src/pages/dashboard/Dashboard.jsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 import { useState, useEffect } from "react";
 import { useAuth } from "../../context/AuthContext";
-import { School, TreePine, Leaf, Cpu } from "lucide-react";
+import { School, TreePine, Leaf, Cpu, Users, Heart } from "lucide-react";
 import { getCentros } from "../../services/centrosService";
 import { getArboles } from "../../services/arbolesService";
 import { getDispositivos } from "../../services/dispositivosService";
@@ -108,6 +108,43 @@ const Dashboard = () => {
             Administra los centros educativos y consulta los árboles asociados a cada uno.
           </p>
         </Link>
+
+        {/* Tarjetas externas */}
+        <div className="grid grid-cols-2 gap-x-6 gap-y-4">
+          <a
+            href="https://proyectoarboles.org/#contacto"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition grid row-span-2 [grid-template-rows:subgrid]"
+          >
+            <div className="flex items-start gap-4">
+              <Users className="w-10 h-10 text-brand-secondary shrink-0" />
+              <h2 className="text-xl font-bold text-brand-primary">
+                Súmate al proyecto
+              </h2>
+            </div>
+            <p className="text-brand-text font-light">
+              Si eres directivo o responsable de un centro, solicita la plantación de árboles y transforma tu colegio en un entorno más verde, saludable y sostenible.
+            </p>
+          </a>
+
+          <a
+            href="https://proyectoarboles.org/#contacto"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition grid row-span-2 [grid-template-rows:subgrid]"
+          >
+            <div className="flex items-start gap-4">
+              <Heart className="w-10 h-10 text-brand-secondary shrink-0" />
+              <h2 className="text-xl font-bold text-brand-primary">
+                Apadrina un árbol
+              </h2>
+            </div>
+            <p className="text-brand-text font-light">
+              Personas, empresas y entidades pueden sumarse apadrinando un árbol: un legado vivo que genera sombra, oxígeno e impacto real frente al cambio climático.
+            </p>
+          </a>
+        </div>
       </div>
 
       {/* Info del usuario */}


### PR DESCRIPTION
## Summary

- **Android y Frontend**: nuevas cards "Súmate al proyecto" y "Apadrina un árbol" en el dashboard, en fila de dos columnas debajo de la card de Centros
- Ambas cards enlazan a `proyectoarboles.org/#contacto` (Android: Intent.ACTION_VIEW / Frontend: target="_blank")
- **Android**: nuevos drawables `ic_users` e `ic_heart`; corrección del path del círculo en `ic_users`
- **Frontend**: uso de CSS subgrid para alinear el texto de descripción; `font-light` en las descripciones para consistencia visual con el resto del dashboard

## Test plan

- [x] Android: verificar que las dos cards aparecen en fila en el dashboard
- [x] Android: pulsar cada card y comprobar que abre el navegador en proyectoarboles.org/#contacto
- [x] Frontend: verificar alineación del texto de descripción en ambas cards
- [x] Frontend: pulsar las cards y comprobar que abren proyectoarboles.org/#contacto en nueva pestaña
- [x] Vercel: verificar deploy del frontend
- [x] Render: verificar deploy del backend