### PR TITLE
fix(android): prevent header from overlapping status bar on Android 15+

### DIFF
--- a/android/app/src/main/res/layout-land/activity_main.xml
+++ b/android/app/src/main/res/layout-land/activity_main.xml
@@ -4,7 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="horizontal"
-    android:background="@color/background_app">
+    android:background="@color/background_app"
+    android:fitsSystemWindows="true">
 
     <com.google.android.material.navigationrail.NavigationRailView
         android:id="@+id/navigation_rail"

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -4,7 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:background="@color/background_app">
+    android:background="@color/background_app"
+    android:fitsSystemWindows="true">
 
     <!-- Header verde borde a borde -->
     <LinearLayout


### PR DESCRIPTION
## Summary

- Añadido `android:fitsSystemWindows="true"` al layout raíz en portrait (`layout/activity_main.xml`) y landscape (`layout-land/activity_main.xml`)
- Corrige el solapamiento del header con la barra de notificaciones causado por el edge-to-edge obligatorio en Android 15+ (API 35+) al tener `targetSdk = 36`

## Test plan

- [x] Verificar en Android 15+ que el header queda por debajo de la status bar
- [x] Verificar que el layout en landscape no tiene el mismo problema
- [x] Comprobar que el comportamiento en versiones anteriores de Android no se ve afectado