### PR TITLE
feat(android+frontend): tree form improvements and dashboard responsive fixes

### DIFF
--- a/android/app/src/main/java/com/example/proyectoarboles/activities/MainActivity.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/activities/MainActivity.java
@@ -60,6 +60,7 @@ public class MainActivity extends AppCompatActivity {
                     permissionManager.clearSession();
                     actualizarMenuSegunPermisos();
                     Toast.makeText(this, "Sesion cerrada", Toast.LENGTH_SHORT).show();
+                    navigateToDashboard();
                 } else {
                     showFragment(new LoginFragment());
                 }

--- a/android/app/src/main/java/com/example/proyectoarboles/fragments/ArbolDetallesFragment.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/fragments/ArbolDetallesFragment.java
@@ -1,6 +1,7 @@
 package com.example.proyectoarboles.fragments;
 
 import android.app.AlertDialog;
+import android.app.DatePickerDialog;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
@@ -32,6 +33,7 @@ import com.example.proyectoarboles.util.PermissionManager;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -48,8 +50,8 @@ public class ArbolDetallesFragment extends Fragment {
     private static final String ARG_ARBOL_ID = "arbol_id";
 
     private TextView tvNombre, tvEspecie, tvFecha, tvUbicacion, tvCentroEducativo, tvAbsorcionCo2, tvCantidad;
-    private TextInputEditText etNombre, etEspecie, etFecha, etUbicacion, etCantidad;
-    private TextInputLayout tilNombre, tilEspecie, tilFecha, tilUbicacion, tilCantidad;
+    private TextInputEditText etNombre, etEspecie, etFecha, etUbicacion, etCantidad, etAbsorcionCo2;
+    private TextInputLayout tilNombre, tilEspecie, tilFecha, tilUbicacion, tilCantidad, tilAbsorcionCo2;
     private Spinner spinnerCentroEducativo;
     private LinearLayout llNombreView, llEspecieView, llFechaView, llCentroView, llUbicacionView, llCantidadView;
     private ImageButton btnEditar, btnEliminar, btnVolver;
@@ -57,6 +59,7 @@ public class ArbolDetallesFragment extends Fragment {
 
     private Arbol arbolActual;
     private long arbolId = -1;
+    private String fechaParaApi = "";
 
     private SharedPreferences sharedPreferences;
     private PermissionManager permissionManager;
@@ -122,11 +125,13 @@ public class ArbolDetallesFragment extends Fragment {
         etFecha = view.findViewById(R.id.editTextFechaDetalle);
         etUbicacion = view.findViewById(R.id.editTextUbicacion);
         etCantidad = view.findViewById(R.id.editTextCantidad);
+        etAbsorcionCo2 = view.findViewById(R.id.editTextAbsorcionCo2);
         tilNombre = view.findViewById(R.id.tilNombreDetalle);
         tilEspecie = view.findViewById(R.id.tilEspecieDetalle);
         tilFecha = view.findViewById(R.id.tilFechaDetalle);
         tilUbicacion = view.findViewById(R.id.tilUbicacion);
         tilCantidad = view.findViewById(R.id.tilCantidad);
+        tilAbsorcionCo2 = view.findViewById(R.id.tilAbsorcionCo2);
 
         spinnerCentroEducativo = view.findViewById(R.id.spinnerCentroEducativo);
         centrosAdapter = new ArrayAdapter<>(requireContext(), android.R.layout.simple_spinner_item, listaCentros);
@@ -208,20 +213,39 @@ public class ArbolDetallesFragment extends Fragment {
         mostrarEditTexts();
     }
 
+    private void mostrarDatePicker() {
+        Calendar cal = Calendar.getInstance();
+        if (!fechaParaApi.isEmpty()) {
+            try {
+                SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
+                Date d = sdf.parse(fechaParaApi);
+                if (d != null) cal.setTime(d);
+            } catch (ParseException ignored) {}
+        }
+        DatePickerDialog picker = new DatePickerDialog(
+                requireContext(),
+                (view, year, month, day) -> {
+                    fechaParaApi = String.format(Locale.getDefault(), "%04d-%02d-%02d", year, month + 1, day);
+                    etFecha.setText(String.format(Locale.getDefault(), "%02d/%02d/%04d", day, month + 1, year));
+                    etFecha.setError(null);
+                },
+                cal.get(Calendar.YEAR),
+                cal.get(Calendar.MONTH),
+                cal.get(Calendar.DAY_OF_MONTH)
+        );
+        picker.getDatePicker().setMaxDate(Calendar.getInstance().getTimeInMillis());
+        picker.show();
+    }
+
     private void guardarCambios() {
         String nombre = etNombre.getText().toString().trim();
         String especie = etEspecie.getText().toString().trim();
-        String fecha = etFecha.getText().toString().trim();
         String ubicacion = etUbicacion.getText().toString().trim();
         String cantidadStr = etCantidad.getText() != null ? etCantidad.getText().toString().trim() : "1";
 
         if (nombre.isEmpty()) { etNombre.setError("El nombre es requerido"); return; }
         if (especie.isEmpty()) { etEspecie.setError("La especie es requerida"); return; }
-        if (fecha.isEmpty()) { etFecha.setError("La fecha es requerida"); return; }
-        if (!validarFecha(fecha)) {
-            etFecha.setError("Fecha inválida. Usa formato YYYY-MM-DD y debe ser en el pasado");
-            return;
-        }
+        if (fechaParaApi.isEmpty()) { etFecha.setError("La fecha es requerida"); return; }
 
         int cantidad;
         try {
@@ -231,6 +255,18 @@ public class ArbolDetallesFragment extends Fragment {
             etCantidad.setError("La cantidad debe ser al menos 1");
             etCantidad.requestFocus();
             return;
+        }
+
+        String co2Str = etAbsorcionCo2.getText() != null ? etAbsorcionCo2.getText().toString().trim() : "";
+        Double absorcionCo2 = null;
+        if (!co2Str.isEmpty()) {
+            try {
+                absorcionCo2 = Double.parseDouble(co2Str.replace(",", "."));
+            } catch (NumberFormatException e) {
+                etAbsorcionCo2.setError("Valor inválido");
+                etAbsorcionCo2.requestFocus();
+                return;
+            }
         }
 
         CentroEducativo centroSeleccionado = (CentroEducativo) spinnerCentroEducativo.getSelectedItem();
@@ -243,10 +279,11 @@ public class ArbolDetallesFragment extends Fragment {
         arbolActualizado.setId(arbolActual.getId());
         arbolActualizado.setNombre(nombre);
         arbolActualizado.setEspecie(especie);
-        arbolActualizado.setFechaPlantacion(fecha);
+        arbolActualizado.setFechaPlantacion(fechaParaApi);
         arbolActualizado.setUbicacion(ubicacion);
         arbolActualizado.setCentroEducativo(centroSeleccionado);
         arbolActualizado.setCantidad(cantidad);
+        arbolActualizado.setAbsorcionCo2Anual(absorcionCo2);
 
         actualizarArbolEnAPI(arbolActual.getId(), arbolActualizado);
     }
@@ -254,17 +291,6 @@ public class ArbolDetallesFragment extends Fragment {
     private void cancelarEdicion() {
         mostrarTextViews();
         verificarPermisosYActualizarUI();
-    }
-
-    private boolean validarFecha(String fechaStr) {
-        try {
-            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
-            sdf.setLenient(false);
-            Date fecha = sdf.parse(fechaStr);
-            return !fecha.after(new Date());
-        } catch (Exception e) {
-            return false;
-        }
     }
 
     private void mostrarTextViews() {
@@ -280,6 +306,7 @@ public class ArbolDetallesFragment extends Fragment {
         spinnerCentroEducativo.setVisibility(View.GONE);
         llCantidadView.setVisibility(View.VISIBLE);
         tilCantidad.setVisibility(View.GONE);
+        tilAbsorcionCo2.setVisibility(View.GONE);
         btnGuardar.setVisibility(View.GONE);
         btnCancelar.setVisibility(View.GONE);
         verificarPermisosYActualizarUI();
@@ -294,7 +321,13 @@ public class ArbolDetallesFragment extends Fragment {
         etEspecie.setText(tvEspecie.getText());
         llFechaView.setVisibility(View.GONE);
         tilFecha.setVisibility(View.VISIBLE);
-        if (arbolActual != null) etFecha.setText(arbolActual.getFechaPlantacion());
+        etFecha.setFocusable(false);
+        etFecha.setFocusableInTouchMode(false);
+        etFecha.setOnClickListener(v -> mostrarDatePicker());
+        if (arbolActual != null && arbolActual.getFechaPlantacion() != null) {
+            fechaParaApi = arbolActual.getFechaPlantacion();
+            etFecha.setText(formatearFechaEspanol(fechaParaApi));
+        }
         llUbicacionView.setVisibility(View.GONE);
         tilUbicacion.setVisibility(View.VISIBLE);
         etUbicacion.setText(tvUbicacion.getText());
@@ -303,6 +336,12 @@ public class ArbolDetallesFragment extends Fragment {
         llCantidadView.setVisibility(View.GONE);
         tilCantidad.setVisibility(View.VISIBLE);
         if (arbolActual != null) etCantidad.setText(String.valueOf(arbolActual.getCantidad()));
+        tilAbsorcionCo2.setVisibility(View.VISIBLE);
+        if (arbolActual != null && arbolActual.getAbsorcionCo2Anual() != null) {
+            etAbsorcionCo2.setText(String.valueOf(arbolActual.getAbsorcionCo2Anual()));
+        } else {
+            etAbsorcionCo2.setText("");
+        }
         btnEditar.setVisibility(View.GONE);
         btnEliminar.setVisibility(View.GONE);
         btnGuardar.setVisibility(View.VISIBLE);

--- a/android/app/src/main/java/com/example/proyectoarboles/fragments/CrearArbolFragment.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/fragments/CrearArbolFragment.java
@@ -1,5 +1,6 @@
 package com.example.proyectoarboles.fragments;
 
+import android.app.DatePickerDialog;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -20,8 +21,7 @@ import com.example.proyectoarboles.model.Arbol;
 import com.example.proyectoarboles.model.CentroEducativo;
 import com.google.android.material.textfield.TextInputEditText;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.util.Calendar;
 import java.util.Locale;
 
 import retrofit2.Call;
@@ -39,6 +39,7 @@ public class CrearArbolFragment extends Fragment {
     private TextInputEditText inputFechaPlantacion;
     private TextInputEditText inputUbicacion;
     private TextInputEditText inputCantidad;
+    private TextInputEditText inputAbsorcionCo2;
     private Button btnCrear;
     private Button btnCancelar;
     private ImageButton btnVolver;
@@ -46,6 +47,7 @@ public class CrearArbolFragment extends Fragment {
 
     private long centroId = -1;
     private String centroNombre = "";
+    private String fechaParaApi = "";
 
     public static CrearArbolFragment newInstance(long centroId, String centroNombre) {
         CrearArbolFragment fragment = new CrearArbolFragment();
@@ -75,6 +77,7 @@ public class CrearArbolFragment extends Fragment {
         inputFechaPlantacion = view.findViewById(R.id.inputFechaPlantacion);
         inputUbicacion = view.findViewById(R.id.inputUbicacion);
         inputCantidad = view.findViewById(R.id.inputCantidad);
+        inputAbsorcionCo2 = view.findViewById(R.id.inputAbsorcionCo2);
         btnCrear = view.findViewById(R.id.btnCrearArbol);
         btnCancelar = view.findViewById(R.id.btnCancelarCrearArbol);
         btnVolver = view.findViewById(R.id.buttonVolverCrearArbol);
@@ -86,6 +89,10 @@ public class CrearArbolFragment extends Fragment {
             return;
         }
 
+        inputFechaPlantacion.setFocusable(false);
+        inputFechaPlantacion.setFocusableInTouchMode(false);
+        inputFechaPlantacion.setOnClickListener(v -> mostrarDatePicker());
+
         btnCrear.setOnClickListener(v -> validarYCrearArbol());
         btnCancelar.setOnClickListener(v ->
                 requireActivity().getSupportFragmentManager().popBackStack());
@@ -93,12 +100,29 @@ public class CrearArbolFragment extends Fragment {
                 requireActivity().getSupportFragmentManager().popBackStack());
     }
 
+    private void mostrarDatePicker() {
+        Calendar hoy = Calendar.getInstance();
+        DatePickerDialog picker = new DatePickerDialog(
+                requireContext(),
+                (view, year, month, day) -> {
+                    fechaParaApi = String.format(Locale.getDefault(), "%04d-%02d-%02d", year, month + 1, day);
+                    inputFechaPlantacion.setText(String.format(Locale.getDefault(), "%02d/%02d/%04d", day, month + 1, year));
+                    inputFechaPlantacion.setError(null);
+                },
+                hoy.get(Calendar.YEAR),
+                hoy.get(Calendar.MONTH),
+                hoy.get(Calendar.DAY_OF_MONTH)
+        );
+        picker.getDatePicker().setMaxDate(hoy.getTimeInMillis());
+        picker.show();
+    }
+
     private void validarYCrearArbol() {
         String nombre = inputNombre.getText() != null ? inputNombre.getText().toString().trim() : "";
         String especie = inputEspecie.getText() != null ? inputEspecie.getText().toString().trim() : "";
-        String fechaStr = inputFechaPlantacion.getText() != null ? inputFechaPlantacion.getText().toString().trim() : "";
         String ubicacion = inputUbicacion.getText() != null ? inputUbicacion.getText().toString().trim() : "";
         String cantidadStr = inputCantidad.getText() != null ? inputCantidad.getText().toString().trim() : "1";
+        String co2Str = inputAbsorcionCo2.getText() != null ? inputAbsorcionCo2.getText().toString().trim() : "";
 
         if (nombre.isEmpty()) {
             inputNombre.setError("El nombre es requerido");
@@ -112,15 +136,8 @@ public class CrearArbolFragment extends Fragment {
             return;
         }
 
-        if (fechaStr.isEmpty()) {
+        if (fechaParaApi.isEmpty()) {
             inputFechaPlantacion.setError("La fecha de plantación es requerida");
-            inputFechaPlantacion.requestFocus();
-            return;
-        }
-
-        if (!validarFecha(fechaStr)) {
-            inputFechaPlantacion.setError("Fecha inválida. Usa formato YYYY-MM-DD y debe ser en el pasado");
-            inputFechaPlantacion.requestFocus();
             return;
         }
 
@@ -134,22 +151,21 @@ public class CrearArbolFragment extends Fragment {
             return;
         }
 
-        crearArbol(nombre, especie, fechaStr, ubicacion, cantidad);
-    }
-
-    private boolean validarFecha(String fechaStr) {
-        try {
-            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
-            sdf.setLenient(false);
-            Date fecha = sdf.parse(fechaStr);
-            return !fecha.after(new Date());
-        } catch (Exception e) {
-            Log.e(TAG, "Error al validar fecha: " + e.getMessage());
-            return false;
+        Double co2 = null;
+        if (!co2Str.isEmpty()) {
+            try {
+                co2 = Double.parseDouble(co2Str.replace(",", "."));
+            } catch (NumberFormatException e) {
+                inputAbsorcionCo2.setError("Valor inválido");
+                inputAbsorcionCo2.requestFocus();
+                return;
+            }
         }
+
+        crearArbol(nombre, especie, fechaParaApi, ubicacion, cantidad, co2);
     }
 
-    private void crearArbol(String nombre, String especie, String fechaPlantacion, String ubicacion, int cantidad) {
+    private void crearArbol(String nombre, String especie, String fechaPlantacion, String ubicacion, int cantidad, Double absorcionCo2) {
         progressBar.setVisibility(View.VISIBLE);
         btnCrear.setEnabled(false);
 
@@ -164,6 +180,7 @@ public class CrearArbolFragment extends Fragment {
         nuevoArbol.setUbicacion(ubicacion);
         nuevoArbol.setCentroEducativo(centro);
         nuevoArbol.setCantidad(cantidad);
+        nuevoArbol.setAbsorcionCo2Anual(absorcionCo2);
 
         Call<Arbol> call = RetrofitClient.getArbolApi().crearArbol(nuevoArbol);
         call.enqueue(new Callback<Arbol>() {

--- a/android/app/src/main/java/com/example/proyectoarboles/fragments/DetalleCentroFragment.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/fragments/DetalleCentroFragment.java
@@ -260,7 +260,9 @@ public class DetalleCentroFragment extends Fragment {
                 if (!isAdded()) return;
                 if (response.isSuccessful() && response.body() != null) {
                     List<Arbol> arboles = response.body();
-                    tvTituloArboles.setText("Árboles del Centro (" + arboles.size() + ")");
+                    int totalArboles = 0;
+                    for (Arbol a : arboles) totalArboles += a.getCantidad();
+                    tvTituloArboles.setText("Árboles del Centro (" + totalArboles + ")");
                     layoutArboles.removeAllViews();
                     if (arboles.isEmpty()) {
                         tvNoArboles.setVisibility(View.VISIBLE);

--- a/android/app/src/main/res/layout/fragment_arbol_detalles.xml
+++ b/android/app/src/main/res/layout/fragment_arbol_detalles.xml
@@ -348,6 +348,25 @@
                         android:textColorHint="@color/text_hint"/>
                 </com.google.android.material.textfield.TextInputLayout>
 
+                <!-- Absorción CO2 (edición) -->
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilAbsorcionCo2"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:visibility="gone"
+                    app:boxBackgroundColor="@color/white"
+                    app:boxStrokeColor="@color/green_primary">
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/editTextAbsorcionCo2"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="Absorción CO₂ anual en kg (opcional)"
+                        android:inputType="numberDecimal"
+                        android:textColor="@color/black"
+                        android:textColorHint="@color/text_hint"/>
+                </com.google.android.material.textfield.TextInputLayout>
+
                 <!-- Absorción CO2 (solo lectura) -->
                 <LinearLayout
                     android:layout_width="match_parent"

--- a/android/app/src/main/res/layout/fragment_crear_arbol.xml
+++ b/android/app/src/main/res/layout/fragment_crear_arbol.xml
@@ -133,8 +133,10 @@
                         android:id="@+id/inputFechaPlantacion"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:hint="Fecha de plantación (YYYY-MM-DD)"
-                        android:inputType="date"
+                        android:hint="Fecha de plantación"
+                        android:inputType="none"
+                        android:focusable="false"
+                        android:focusableInTouchMode="false"
                         android:textColor="@color/black"
                         android:textColorHint="@color/text_hint" />
 
@@ -172,6 +174,24 @@
                         android:hint="Cantidad de árboles (mínimo 1)"
                         android:inputType="number"
                         android:text="1"
+                        android:textColor="@color/black"
+                        android:textColorHint="@color/text_hint" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="4dp"
+                    app:boxBackgroundColor="@color/white"
+                    app:boxStrokeColor="@color/green_primary">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/inputAbsorcionCo2"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="Absorción CO₂ anual en kg (opcional)"
+                        android:inputType="numberDecimal"
                         android:textColor="@color/black"
                         android:textColorHint="@color/text_hint" />
 

--- a/frontend/src/pages/dashboard/Dashboard.jsx
+++ b/frontend/src/pages/dashboard/Dashboard.jsx
@@ -41,40 +41,32 @@ const Dashboard = () => {
       </div>
 
       {/* Métricas */}
-      <div className="bg-brand-primary rounded-lg shadow-md px-8 py-5 mb-6 flex divide-x divide-white/20">
-        <div className="flex items-center gap-3 pr-8">
+      <div className="bg-brand-primary rounded-lg shadow-md p-5 mb-6 grid grid-cols-2 sm:grid-cols-4 gap-4">
+        <div className="flex items-center gap-3">
           <School className="w-7 h-7 text-brand-bg-green shrink-0" />
           <div>
-            <p className="text-2xl font-bold text-white leading-none">
-              {numCentros ?? '…'}
-            </p>
+            <p className="text-2xl font-bold text-white leading-none">{numCentros ?? '…'}</p>
             <p className="text-xs text-white/60 mt-1">Centros educativos</p>
           </div>
         </div>
-        <div className="flex items-center gap-3 px-8">
+        <div className="flex items-center gap-3">
           <TreePine className="w-7 h-7 text-brand-bg-green shrink-0" />
           <div>
-            <p className="text-2xl font-bold text-white leading-none">
-              {numArboles ?? '…'}
-            </p>
+            <p className="text-2xl font-bold text-white leading-none">{numArboles ?? '…'}</p>
             <p className="text-xs text-white/60 mt-1">Árboles plantados</p>
           </div>
         </div>
-        <div className="flex items-center gap-3 px-8">
+        <div className="flex items-center gap-3">
           <Cpu className="w-7 h-7 text-brand-bg-green shrink-0" />
           <div>
-            <p className="text-2xl font-bold text-white leading-none">
-              {dispositivosActivos ?? '…'}
-            </p>
+            <p className="text-2xl font-bold text-white leading-none">{dispositivosActivos ?? '…'}</p>
             <p className="text-xs text-white/60 mt-1">Dispositivos activos</p>
           </div>
         </div>
-        <div className="flex items-center gap-3 pl-8">
+        <div className="flex items-center gap-3">
           <Leaf className="w-7 h-7 text-brand-bg-green shrink-0" />
           <div>
-            <p className="text-2xl font-bold text-white leading-none">
-              {co2Total ?? '…'}
-            </p>
+            <p className="text-2xl font-bold text-white leading-none">{co2Total ?? '…'}</p>
             <p className="text-xs text-white/60 mt-1">kg CO₂ absorbidos/año</p>
           </div>
         </div>
@@ -99,14 +91,14 @@ const Dashboard = () => {
         </Link>
 
         {/* Tarjetas externas */}
-        <div className="grid grid-cols-2 gap-x-6 gap-y-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
           <a
             href="https://proyectoarboles.org/#contacto"
             target="_blank"
             rel="noopener noreferrer"
-            className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition grid row-span-2 [grid-template-rows:subgrid]"
+            className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition"
           >
-            <div className="flex items-start gap-4">
+            <div className="flex items-start gap-4 mb-3">
               <Users className="w-10 h-10 text-brand-secondary shrink-0" />
               <h2 className="text-xl font-bold text-brand-primary">
                 Súmate al proyecto
@@ -121,9 +113,9 @@ const Dashboard = () => {
             href="https://proyectoarboles.org/#contacto"
             target="_blank"
             rel="noopener noreferrer"
-            className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition grid row-span-2 [grid-template-rows:subgrid]"
+            className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition"
           >
-            <div className="flex items-start gap-4">
+            <div className="flex items-start gap-4 mb-3">
               <Heart className="w-10 h-10 text-brand-secondary shrink-0" />
               <h2 className="text-xl font-bold text-brand-primary">
                 Apadrina un árbol
@@ -137,7 +129,7 @@ const Dashboard = () => {
       </div>
 
       {/* Descripción del proyecto */}
-      <div className="bg-white rounded-lg shadow-md p-6 mt-6 space-y-3 text-brand-text leading-relaxed font-light">
+      <div className="bg-white rounded-lg shadow-md p-6 mt-6 space-y-3 text-brand-text leading-relaxed font-light text-justify">
         <p>
           El <span className="font-medium text-brand-primary">Proyecto Árboles</span> es una iniciativa impulsada por la <span className="font-medium">Fundación Sergio Alonso</span>, la <span className="font-medium">Fundación Acuorum</span> y la <span className="font-medium">Fundación Foresta</span> que promueve la educación ambiental y la acción climática a través de la plantación de árboles en centros educativos de Canarias.
         </p>


### PR DESCRIPTION
## Summary

- fix(android): navigate to dashboard after logout so user metrics card clears correctly
- feat(android): replace date text fields with DatePickerDialog (DD/MM/YYYY display, YYYY-MM-DD to API) and add optional CO2 absorption field to both CrearArbol and ArbolDetalles forms
- fix(android): sum `cantidad` field for total tree count in centro detail instead of counting records
- fix(frontend): make dashboard metrics bar responsive (2×2 on mobile, 4-col on sm+), make external link cards collapse to single column on mobile, add text-justify to description card

## Test plan

- [x] Android: log out and confirm dashboard no longer shows user name/role
- [x] Android: open CrearArbol form, tap date field — DatePickerDialog opens; future dates are disabled; date appears as DD/MM/YYYY
- [x] Android: create a tree with CO2 value and confirm it's saved correctly
- [x] Android: open ArbolDetalles, tap Edit, verify date picker pre-fills with existing date and CO2 field shows current value
- [x] Android: save changes and confirm CO2 is updated
- [x] Android: open a centro with multiple tree records — total count reflects sum of quantities, not number of records
- [x] Frontend: resize browser to mobile width — metrics show 2×2, cards stack vertically
- [x] Frontend: description card text is justified