### PR TITLE
feat(backend): add DELETE endpoint for lecturas

### DIFF
--- a/backend/src/main/java/com/example/gardenmonitor/controller/LecturaController.java
+++ b/backend/src/main/java/com/example/gardenmonitor/controller/LecturaController.java
@@ -182,4 +182,23 @@ public class LecturaController {
 
         return lecturaRepository.findMuestraByDispositivoAndRango(dispositivo.getId(), desde, hasta);
     }
+
+    /**
+     * Elimina una lectura por su identificador.
+     * <p>
+     * Permite borrar lecturas erróneas o corruptas registradas por un dispositivo.
+     * </p>
+     *
+     * @param id identificador de la lectura a eliminar
+     * @return la lectura eliminada
+     * @throws ResponseStatusException si no se encuentra la lectura (404)
+     */
+    @DeleteMapping("/{id}")
+    public Lectura eliminarLectura(@PathVariable("id") Long id) {
+        Lectura lectura = lecturaRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Lectura no encontrada"));
+        lecturaRepository.deleteById(id);
+        return lectura;
+    }
 }


### PR DESCRIPTION
## Summary

- Add `DELETE /api/lecturas/{id}` to `LecturaController`
- Returns 404 if the reading is not found
- Returns the deleted record on success
- Completes full CRUD coverage for all entities in the database

## Test plan

- [x] `DELETE /api/lecturas/{id}` with valid id returns 200 and the deleted record
- [x] `DELETE /api/lecturas/{id}` with unknown id returns 404