### PR TITLE
feat(frontend): hooks useFetch/useForm, real-time validation, fieldset UX and docs

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -280,6 +280,195 @@ Todos los formularios incluyen validación client-side:
 - Confirmación de contraseña
 - Rangos numéricos (umbrales) — en FormularioDispositivo
 
+## Decisiones Técnicas
+
+### Context API vs Redux
+Se optó por **Context API** para la gestión de estado porque la aplicación solo requiere compartir el estado de autenticación (`AuthContext`) a nivel global. Redux introduce complejidad innecesaria (actions, reducers, store) para un único store de usuario. Si el proyecto creciera con múltiples fuentes de estado global (carrito, notificaciones en tiempo real, etc.), se replantearía Zustand o Redux Toolkit.
+
+### Polling vs WebSocket
+El histórico de lecturas IoT usa **polling** (`setInterval` según `frecuenciaLecturaSeg` del dispositivo) en lugar de WebSocket porque:
+- El ESP32 envía datos por HTTP REST (push unidireccional): no existe conexión persistente en el servidor.
+- La frecuencia de actualización es configurable por dispositivo (5–3600 s) y no requiere tiempo real estricto.
+- Simplifica el backend (sin servidor WebSocket) y reduce costes en Render (free tier).
+
+### Recharts vs Chart.js
+Se eligió **Recharts** 3.x porque está construido sobre composición de componentes React (más idiomático), tiene soporte nativo de TypeScript y se integra mejor con el ciclo de vida de React que Chart.js (basado en canvas imperativo). Chart.js requiere más código imperativo (`useRef` + `chart.destroy()`) para gestionar correctamente el ciclo de vida.
+
+### Leaflet (React Leaflet)
+Para los mapas en `DetalleCentro` se usa **Leaflet + React Leaflet** en lugar de Google Maps porque es gratuito sin cuotas de API, usa tiles de OpenStreetMap sin dependencia de terceros, y su bundle size es razonable para el tipo de mapa requerido.
+
+### Axios vs Fetch nativo
+Axios centraliza la configuración base (`baseURL`, interceptores de error) en `api.js`. El Fetch nativo requeriría más boilerplate para manejar errores HTTP y serialización JSON. El interceptor de Axios redirige automáticamente al login cuando el servidor devuelve 401.
+
+### Custom hooks: `useFetch` y `useForm`
+Para eliminar la duplicación de lógica `loading/error` en los tres listados se creó `useFetch`. Para reutilizar la gestión de estado de formulario (values, errors, touched, validación en tiempo real tras primer blur) se creó `useForm`. Siguiendo el principio de separación de responsabilidades: las páginas describen la UI, los hooks encapsulan el comportamiento.
+
+---
+
+## Arquitectura de Componentes
+
+### Capas de la aplicación
+
+```
+src/
+├── pages/          → Vistas: orquestan hooks, servicios y componentes comunes
+├── components/
+│   └── common/     → UI reutilizable sin lógica de negocio (Button, Input, Alert, Spinner)
+├── hooks/          → Lógica reutilizable: useFetch, useForm, usePermissions
+├── services/       → Llamadas HTTP con Axios (una función = un endpoint)
+├── context/        → Estado global compartido (solo AuthContext)
+├── utils/          → Funciones puras de negocio (permissions.js)
+└── constants/      → Datos estáticos (islas.js, roles.js)
+```
+
+### Diagrama de dependencias
+
+```mermaid
+graph TD
+    subgraph Pages
+        LA[ListadoArboles] --> UF[useFetch]
+        LC[ListadoCentros] --> UF
+        LU[ListadoUsuarios] --> UF
+        FA[FormularioArbol] --> UFM[useForm]
+        FD[FormularioDispositivo] --> UFM
+    end
+
+    subgraph Hooks
+        UF --> SRV[services/]
+        UFM --> INP[Input.jsx]
+        UP[usePermissions] --> AC[AuthContext]
+    end
+
+    subgraph Common
+        BTN[Button]
+        INP[Input]
+        ALR[Alert]
+        SPR[Spinner]
+    end
+
+    LA --> BTN & ALR & SPR & UP
+    LC --> BTN & ALR & SPR & UP
+    FA --> INP & BTN & ALR & SPR & UP
+    FD --> INP & BTN & ALR & SPR
+```
+
+### Flujo de datos de un listado
+
+```
+Page mount
+  └─ useFetch(serviceFn)
+       ├─ loading = true
+       ├─ await serviceFn()   ← Axios → REST API
+       ├─ data = result
+       └─ loading = false
+            └─ Page renders table/cards with data
+```
+
+### Flujo de validación en tiempo real (formularios)
+
+```
+User types in Input
+  └─ onChange → useForm.handleChange
+       ├─ if field is touched: validate(values) → set field error
+       └─ else: clear field error
+
+User leaves Input (blur)
+  └─ Input.handleBlur → setTouched(true) → useForm.handleBlur
+       └─ validate(values) → set field error (if any)
+
+User submits form
+  └─ useForm.validateAll() → validate all fields → show all errors
+```
+
+---
+
+## Guía de Desarrollo: Añadir una nueva página CRUD
+
+Ejemplo completo: añadir gestión de **Parcelas**.
+
+### Paso 1 — Servicio (`src/services/parcelasService.js`)
+
+```javascript
+import api from './api';
+
+export const getParcelas    = ()       => api.get('/parcelas').then(r => r.data);
+export const getParcelaById = (id)     => api.get(`/parcelas/${id}`).then(r => r.data);
+export const createParcela  = (data)   => api.post('/parcelas', data).then(r => r.data);
+export const updateParcela  = (id, d)  => api.put(`/parcelas/${id}`, d).then(r => r.data);
+export const deleteParcela  = (id)     => api.delete(`/parcelas/${id}`);
+```
+
+### Paso 2 — Listado (`src/pages/parcelas/ListadoParcelas.jsx`)
+
+```javascript
+import { useFetch } from '../../hooks/useFetch';
+import { getParcelas } from '../../services/parcelasService';
+
+function ListadoParcelas() {
+  const { data, loading, error, setError } = useFetch(getParcelas);
+  const parcelas = data ?? [];
+  // ...render table + spinner + alert
+}
+```
+
+### Paso 3 — Formulario (`src/pages/parcelas/FormularioParcela.jsx`)
+
+```javascript
+import { useForm } from '../../hooks/useForm';
+
+const validate = (values) => {
+  const errors = {};
+  if (!values.nombre.trim()) errors.nombre = 'El nombre es obligatorio';
+  return errors;
+};
+
+function FormularioParcela() {
+  const { values, errors, handleChange, handleBlur, validateAll } =
+    useForm({ nombre: '', superficie: '' }, validate);
+
+  // Usar <Input onBlur={handleBlur} /> para validación en tiempo real
+}
+```
+
+### Paso 4 — Rutas (`src/App.jsx`)
+
+```javascript
+<Route path="/parcelas"             element={<ListadoParcelas />} />
+<Route path="/parcelas/nuevo"       element={<FormularioParcela />} />
+<Route path="/parcelas/:id/editar"  element={<FormularioParcela />} />
+```
+
+### Paso 5 — Menú (`src/layout/Header.jsx`)
+
+Añadir un nuevo `<NavLink to="/parcelas">` en el array de ítems de navegación del Header.
+
+---
+
+## Tests
+
+El proyecto incluye una suite de tests automatizados en `src/tests/` con **Vitest** y **React Testing Library**:
+
+| Archivo | Qué cubre |
+|---|---|
+| `arbolesService.test.js` | CRUD de árboles mockeando Axios |
+| `lecturasService.test.js` | Servicio de lecturas IoT |
+| `AuthContext.test.jsx` | Login, logout, persistencia en localStorage |
+| `FormularioArbol.test.jsx` | Validaciones del formulario de árbol |
+| `Login.test.jsx` | Renderizado y submit del formulario de login |
+| `permissions.test.js` | Lógica de permisos por rol |
+| `ProtectedRoute.test.jsx` | Redirección de rutas protegidas |
+
+Para ejecutar los tests:
+
+```bash
+npm run test            # Ejecuta todos los tests en modo watch
+npm run test -- --run   # Ejecución única (CI)
+```
+
+Los tests usan **mocks de Axios** para aislar la capa de servicios del backend real. Los tests de componentes simulan interacciones reales del usuario con `@testing-library/user-event`.
+
+---
+
 ## Estilos y Componentes
 
 - **Tailwind CSS**: Para estilos utilitarios

--- a/frontend/src/components/common/Input.jsx
+++ b/frontend/src/components/common/Input.jsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 const Input = ({
   id,
   name,
@@ -6,12 +8,23 @@ const Input = ({
   placeholder,
   value,
   onChange,
+  onBlur: externalOnBlur,
   error,
   required = false,
   disabled = false,
   className = "",
   ...rest
 }) => {
+  const [touched, setTouched] = useState(false);
+
+  const handleBlur = (e) => {
+    setTouched(true);
+    externalOnBlur?.(e);
+  };
+
+  // Borde verde tras primer blur si el campo tiene valor y no hay error
+  const isValid = touched && !error && Boolean(value);
+
   return (
     <div className="w-full">
       {label && (
@@ -30,16 +43,21 @@ const Input = ({
         type={type}
         value={value}
         onChange={onChange}
+        onBlur={handleBlur}
         placeholder={placeholder}
         disabled={disabled}
         required={required}
         className={`
-            w-full px-3 py-2 border rounded-md
-            focus:outline-none focus:ring-2 focus:ring-brand-primary
-            disabled:bg-gray-100 disabled:cursor-not-allowed
-            ${error ? 'border-red-500' : 'border-gray-300'}
-            ${className}
-          `}
+          w-full px-3 py-2 border rounded-md transition-colors
+          focus:outline-none focus:ring-2
+          disabled:bg-gray-100 disabled:cursor-not-allowed
+          ${error
+            ? 'border-red-500 focus:ring-red-400'
+            : isValid
+            ? 'border-green-500 focus:ring-green-400'
+            : 'border-gray-300 focus:ring-brand-primary'}
+          ${className}
+        `}
         {...rest}
       />
 

--- a/frontend/src/hooks/useFetch.js
+++ b/frontend/src/hooks/useFetch.js
@@ -1,0 +1,32 @@
+import { useState, useEffect, useRef } from 'react';
+
+const SERVER_ERROR =
+  'No se pudo conectar con el servidor. Si es la primera carga, puede estar iniciándose (30-60 seg). Recarga la página en unos momentos.';
+
+export function useFetch(fetchFn, initialData = null) {
+  const [data, setData] = useState(initialData);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const fetchRef = useRef(fetchFn);
+  fetchRef.current = fetchFn;
+
+  const execute = async () => {
+    try {
+      setLoading(true);
+      setError('');
+      const result = await fetchRef.current();
+      setData(result);
+    } catch (err) {
+      console.error('useFetch error:', err);
+      setError(SERVER_ERROR);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    execute();
+  }, []);
+
+  return { data, setData, loading, setLoading, error, setError, refetch: execute };
+}

--- a/frontend/src/hooks/useForm.js
+++ b/frontend/src/hooks/useForm.js
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+
+/**
+ * Hook para gestionar el estado de un formulario con validación en tiempo real.
+ *
+ * @param {object} initialValues - Valores iniciales del formulario
+ * @param {function} validate    - (values) => errorsObject — función de validación pura
+ * @param {object}  transforms   - Mapa de transformaciones por campo, p.ej. { centroEducativo: v => ({ id: v }) }
+ */
+export function useForm(initialValues, validate, transforms = {}) {
+  const [values, setValues] = useState(initialValues);
+  const [errors, setErrors] = useState({});
+  const [touched, setTouched] = useState({});
+
+  const handleChange = (e) => {
+    const { name, value, type, checked } = e.target;
+    let newValue = type === 'checkbox' ? checked : value;
+    if (transforms[name]) newValue = transforms[name](newValue);
+
+    const next = { ...values, [name]: newValue };
+    setValues(next);
+
+    if (touched[name] && validate) {
+      const errs = validate(next);
+      setErrors(prev => ({ ...prev, [name]: errs[name] || '' }));
+    } else if (errors[name]) {
+      setErrors(prev => ({ ...prev, [name]: '' }));
+    }
+  };
+
+  // Marca el campo como tocado y valida al salir del campo
+  const handleBlur = (e) => {
+    const { name } = e.target;
+    setTouched(prev => ({ ...prev, [name]: true }));
+    if (validate) {
+      const errs = validate(values);
+      setErrors(prev => ({ ...prev, [name]: errs[name] || '' }));
+    }
+  };
+
+  // Valida todos los campos (se llama en onSubmit)
+  const validateAll = () => {
+    if (!validate) return true;
+    const allErrors = validate(values);
+    setErrors(allErrors);
+    return !Object.values(allErrors).some(Boolean);
+  };
+
+  return {
+    values,
+    setValues,
+    errors,
+    setErrors,
+    touched,
+    setTouched,
+    handleChange,
+    handleBlur,
+    validateAll,
+  };
+}

--- a/frontend/src/pages/arboles/FormularioArbol.jsx
+++ b/frontend/src/pages/arboles/FormularioArbol.jsx
@@ -1,374 +1,341 @@
-  import { useState, useEffect } from 'react';
-  import { useParams, useNavigate, useLocation } from 'react-router-dom';
-  import { getArbolById, createArbol, updateArbol } from '../../services/arbolesService';
-  import { getCentros } from '../../services/centrosService';
-  import Input from '../../components/common/Input';
-  import Button from '../../components/common/Button';
-  import Spinner from '../../components/common/Spinner';
-  import Alert from '../../components/common/Alert';
-  import { usePermissions } from '../../hooks/usePermissions';
-  import { useAuth } from '../../context/AuthContext';
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { getArbolById, createArbol, updateArbol } from '../../services/arbolesService';
+import { getCentros } from '../../services/centrosService';
+import { useForm } from '../../hooks/useForm';
+import Input from '../../components/common/Input';
+import Button from '../../components/common/Button';
+import Spinner from '../../components/common/Spinner';
+import Alert from '../../components/common/Alert';
+import { usePermissions } from '../../hooks/usePermissions';
+import { useAuth } from '../../context/AuthContext';
 
-  function FormularioArbol() {
-    const { id } = useParams();
-    const navigate = useNavigate();
-    const location = useLocation();
-    const isEditMode = Boolean(id);
+const validarArbol = (values) => {
+  const errors = {};
+  if (!values.nombre.trim()) errors.nombre = 'El nombre es obligatorio';
+  if (!values.especie.trim()) errors.especie = 'La especie es obligatoria';
+  if (!values.fechaPlantacion) {
+    errors.fechaPlantacion = 'La fecha de plantación es obligatoria';
+  } else {
+    const hoy = new Date();
+    hoy.setHours(0, 0, 0, 0);
+    if (new Date(values.fechaPlantacion) > hoy) {
+      errors.fechaPlantacion = 'La fecha de plantación no puede ser futura';
+    }
+  }
+  if (!values.centroEducativo?.id) errors.centroEducativo = 'Debes seleccionar un centro educativo';
+  const cantidadNum = parseInt(values.cantidad);
+  if (!cantidadNum || cantidadNum < 1) errors.cantidad = 'La cantidad debe ser al menos 1';
+  return errors;
+};
 
-    // Estados del formulario
-    const centroIdDesdeState = location.state?.centroId;
-    const [formData, setFormData] = useState({
-      nombre: '',
-      especie: '',
-      fechaPlantacion: '',
-      ubicacionEspecifica: '',
-      centroEducativo: { id: centroIdDesdeState || '' },
-      absorcionCo2Anual: '',
-      cantidad: 1
-    });
+function FormularioArbol() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const isEditMode = Boolean(id);
 
-    const [centros, setCentros] = useState([]);
-    const [loading, setLoading] = useState(false);
-    const [loadingData, setLoadingData] = useState(isEditMode);
-    const [error, setError] = useState('');
-    const [errors, setErrors] = useState({});
-    const { isAdmin } = usePermissions();
-    const { user } = useAuth();
+  const centroIdDesdeState = location.state?.centroId;
+  const initialValues = {
+    nombre: '',
+    especie: '',
+    fechaPlantacion: '',
+    ubicacionEspecifica: '',
+    centroEducativo: { id: centroIdDesdeState || '' },
+    absorcionCo2Anual: '',
+    cantidad: 1,
+  };
 
-    // ADMIN ve todos los centros, COORDINADOR solo los suyos
-    const centrosFiltrados = isAdmin()
-      ? centros
-      : centros.filter(c => user?.centros?.some(uc => uc.centroId === c.id));
+  const {
+    values: formData,
+    setValues: setFormData,
+    errors,
+    handleChange,
+    handleBlur,
+    validateAll,
+  } = useForm(
+    initialValues,
+    validarArbol,
+    { centroEducativo: (v) => ({ id: v }) }
+  );
 
-    // Cargar centros y datos del árbol (si es edición)
-    useEffect(() => {
-      cargarDatosIniciales();
-    }, [id]);
+  const [centros, setCentros] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [loadingData, setLoadingData] = useState(isEditMode);
+  const [error, setError] = useState('');
+  const { isAdmin } = usePermissions();
+  const { user } = useAuth();
 
-    const cargarDatosIniciales = async () => {
-      try {
-        const centrosData = await getCentros();
-        setCentros(centrosData);
+  const centrosFiltrados = isAdmin()
+    ? centros
+    : centros.filter(c => user?.centros?.some(uc => uc.centroId === c.id));
 
-        if (isEditMode) {
-          setLoadingData(true);
-          const arbolData = await getArbolById(id);
+  useEffect(() => {
+    cargarDatosIniciales();
+  }, [id]);
 
-          // Formatear fecha para el input (YYYY-MM-DD)
-          const fechaFormateada = arbolData.fechaPlantacion
-            ? new Date(arbolData.fechaPlantacion).toISOString().split('T')[0]
-            : '';
+  const cargarDatosIniciales = async () => {
+    try {
+      const centrosData = await getCentros();
+      setCentros(centrosData);
 
-          setFormData({
-            nombre: arbolData.nombre || '',
-            especie: arbolData.especie || '',
-            fechaPlantacion: fechaFormateada,
-            ubicacionEspecifica: arbolData.ubicacionEspecifica || '',
-            centroEducativo: { id: arbolData.centroEducativo?.id || '' },
-            absorcionCo2Anual: arbolData.absorcionCo2Anual || '',
-            cantidad: arbolData.cantidad ?? 1
-          });
-        }
-      } catch (err) {
-        console.error('Error cargando datos iniciales:', err);
-        setError('No se pudo conectar con el servidor. Si es la primera carga, puede estar iniciándose (30-60 seg). Recarga la página en unos momentos.');
-      } finally {
-        setLoadingData(false);
+      if (isEditMode) {
+        setLoadingData(true);
+        const arbolData = await getArbolById(id);
+        const fechaFormateada = arbolData.fechaPlantacion
+          ? new Date(arbolData.fechaPlantacion).toISOString().split('T')[0]
+          : '';
+        setFormData({
+          nombre: arbolData.nombre || '',
+          especie: arbolData.especie || '',
+          fechaPlantacion: fechaFormateada,
+          ubicacionEspecifica: arbolData.ubicacionEspecifica || '',
+          centroEducativo: { id: arbolData.centroEducativo?.id || '' },
+          absorcionCo2Anual: arbolData.absorcionCo2Anual || '',
+          cantidad: arbolData.cantidad ?? 1,
+        });
       }
-    };
+    } catch (err) {
+      console.error('Error cargando datos iniciales:', err);
+      setError('No se pudo conectar con el servidor. Si es la primera carga, puede estar iniciándose (30-60 seg). Recarga la página en unos momentos.');
+    } finally {
+      setLoadingData(false);
+    }
+  };
 
-    const handleChange = (e) => {
-      const { name, value } = e.target;
+  const handleSubmit = async (e) => {
+    e.preventDefault();
 
-      if (name === 'centroEducativo') {
-        setFormData(prev => ({
-          ...prev,
-          centroEducativo: { id: value }
-        }));
-      } else {
-        setFormData(prev => ({
-          ...prev,
-          [name]: value
-        }));
-      }
-
-      // Limpiar error del campo cuando el usuario empieza a escribir
-      if (errors[name]) {
-        setErrors(prev => ({
-          ...prev,
-          [name]: ''
-        }));
-      }
-    };
-
-    const validarFormulario = () => {
-      const nuevosErrores = {};
-
-      // Validaciones de campos obligatorios
-      if (!formData.nombre.trim()) {
-        nuevosErrores.nombre = 'El nombre es obligatorio';
-      }
-
-      if (!formData.especie.trim()) {
-        nuevosErrores.especie = 'La especie es obligatoria';
-      }
-
-      if (!formData.fechaPlantacion) {
-        nuevosErrores.fechaPlantacion = 'La fecha de plantación es obligatoria';
-      } else {
-        // Validar que la fecha no sea futura
-        const fechaSeleccionada = new Date(formData.fechaPlantacion);
-        const hoy = new Date();
-        hoy.setHours(0, 0, 0, 0);
-
-        if (fechaSeleccionada > hoy) {
-          nuevosErrores.fechaPlantacion = 'La fecha de plantación no puede ser futura';
-        }
-      }
-
-      if (!formData.centroEducativo.id) {
-        nuevosErrores.centroEducativo = 'Debes seleccionar un centro educativo';
-      }
-
-      const cantidadNum = parseInt(formData.cantidad);
-      if (!cantidadNum || cantidadNum < 1) {
-        nuevosErrores.cantidad = 'La cantidad debe ser al menos 1';
-      }
-
-      // Validaciones de umbrales (si están presentes)
-      setErrors(nuevosErrores);
-      return Object.keys(nuevosErrores).length === 0;
-    };
-
-    const handleSubmit = async (e) => {
-      e.preventDefault();
-
-      if (!validarFormulario()) {
-        setError('Por favor, corrige los errores en el formulario');
-        return;
-      }
-
-      try {
-        setLoading(true);
-        setError('');
-
-        // Preparar datos para enviar
-        const dataToSend = {
-          nombre: formData.nombre.trim(),
-          especie: formData.especie.trim(),
-          fechaPlantacion: formData.fechaPlantacion,
-          ubicacionEspecifica: formData.ubicacionEspecifica.trim() || null,
-          centroEducativo: { id: parseInt(formData.centroEducativo.id) },
-          absorcionCo2Anual: formData.absorcionCo2Anual !== '' ? parseFloat(formData.absorcionCo2Anual) : null,
-          cantidad: parseInt(formData.cantidad) || 1
-        };
-
-        if (isEditMode) {
-          await updateArbol(id, dataToSend);
-          navigate(`/arboles/${id}`, {
-            state: { message: 'Árbol actualizado correctamente' }
-          });
-        } else {
-          const nuevoArbol = await createArbol(dataToSend);
-          navigate(`/arboles/${nuevoArbol.id}`, {
-            state: { message: 'Árbol creado correctamente' }
-          });
-        }
-      } catch (err) {
-        console.error('Error guardando árbol:', err);
-        setError(
-          err.response?.data?.message ||
-          `Error al ${isEditMode ? 'actualizar' : 'crear'} el árbol. Por favor, intenta de nuevo.`
-        );
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    const handleCancel = () => {
-      navigate(-1);
-    };
-
-    if (loadingData) {
-      return (
-        <div className="flex justify-center items-center py-12">
-          <Spinner size="lg" text="Cargando datos..." />
-        </div>
-      );
+    if (!validateAll()) {
+      setError('Por favor, corrige los errores en el formulario');
+      return;
     }
 
+    try {
+      setLoading(true);
+      setError('');
+
+      const dataToSend = {
+        nombre: formData.nombre.trim(),
+        especie: formData.especie.trim(),
+        fechaPlantacion: formData.fechaPlantacion,
+        ubicacionEspecifica: formData.ubicacionEspecifica.trim() || null,
+        centroEducativo: { id: parseInt(formData.centroEducativo.id) },
+        absorcionCo2Anual: formData.absorcionCo2Anual !== '' ? parseFloat(formData.absorcionCo2Anual) : null,
+        cantidad: parseInt(formData.cantidad) || 1,
+      };
+
+      if (isEditMode) {
+        await updateArbol(id, dataToSend);
+        navigate(`/arboles/${id}`, {
+          state: { message: 'Árbol actualizado correctamente' },
+        });
+      } else {
+        const nuevoArbol = await createArbol(dataToSend);
+        navigate(`/arboles/${nuevoArbol.id}`, {
+          state: { message: 'Árbol creado correctamente' },
+        });
+      }
+    } catch (err) {
+      console.error('Error guardando árbol:', err);
+      setError(
+        err.response?.data?.message ||
+        `Error al ${isEditMode ? 'actualizar' : 'crear'} el árbol. Por favor, intenta de nuevo.`
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCancel = () => navigate(-1);
+
+  if (loadingData) {
     return (
-      <div className="container mx-auto px-4 py-8">
-        <div className="max-w-3xl mx-auto">
-          <div className="mb-6">
-            <h1 className="text-3xl font-bold text-gray-800">
-              {isEditMode ? 'Editar Árbol' : 'Nuevo Árbol'}
-            </h1>
-            <p className="text-gray-600 mt-1">
-              {isEditMode
-                ? 'Modifica los datos del árbol'
-                : 'Completa el formulario para añadir un nuevo árbol'}
-            </p>
-          </div>
-
-          {error && (
-            <div className="mb-4">
-              <Alert
-                type="error"
-                message={error}
-                onClose={() => setError('')}
-                dismissible
-              />
-            </div>
-          )}
-
-          <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow-md p-6">
-            {/* Sección: Información General */}
-            <div className="mb-6">
-              <h2 className="text-xl font-semibold text-gray-800 mb-4">Información General</h2>
-
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {/* Nombre */}
-                <Input
-                  id="nombre"
-                  name="nombre"
-                  label="Nombre del Árbol"
-                  type="text"
-                  value={formData.nombre}
-                  onChange={handleChange}
-                  error={errors.nombre}
-                  required
-                  placeholder="Ej: Pino Canario del Patio"
-                />
-
-                {/* Especie */}
-                <Input
-                  id="especie"
-                  name="especie"
-                  label="Especie"
-                  type="text"
-                  value={formData.especie}
-                  onChange={handleChange}
-                  error={errors.especie}
-                  required
-                  placeholder="Ej: Pinus canariensis"
-                />
-
-                {/* Centro Educativo */}
-                <div>
-                  <label htmlFor="centroEducativo" className="block text-sm font-medium text-gray-700 mb-1">
-                    Centro Educativo <span className="text-red-500">*</span>
-                  </label>
-                  <select
-                    id="centroEducativo"
-                    name="centroEducativo"
-                    value={formData.centroEducativo.id}
-                    onChange={handleChange}
-                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-brand-primary ${
-                      errors.centroEducativo ? 'border-red-500' : 'border-gray-300'
-                    }`}
-                    required
-                  >
-                    <option value="">Selecciona un centro</option>
-                    {centrosFiltrados.map(centro => (
-                      <option key={centro.id} value={centro.id}>
-                        {centro.nombre}
-                      </option>
-                    ))}
-                  </select>
-                  {errors.centroEducativo && (
-                    <p className="mt-1 text-sm text-red-500">{errors.centroEducativo}</p>
-                  )}
-                </div>
-
-                {/* Fecha de Plantación */}
-                <Input
-                  id="fechaPlantacion"
-                  name="fechaPlantacion"
-                  label="Fecha de Plantación"
-                  type="date"
-                  value={formData.fechaPlantacion}
-                  onChange={handleChange}
-                  error={errors.fechaPlantacion}
-                  required
-                />
-
-                {/* Ubicación Específica */}
-                <div className="md:col-span-2">
-                  <Input
-                    id="ubicacionEspecifica"
-                    name="ubicacionEspecifica"
-                    label="Ubicación Específica"
-                    type="text"
-                    value={formData.ubicacionEspecifica}
-                    onChange={handleChange}
-                    placeholder="Ej: Patio principal, junto a la entrada"
-                  />
-                </div>
-
-                {/* Cantidad */}
-                <div>
-                  <Input
-                    id="cantidad"
-                    name="cantidad"
-                    label="Cantidad de árboles"
-                    type="number"
-                    min="1"
-                    value={formData.cantidad}
-                    onChange={handleChange}
-                    error={errors.cantidad}
-                    required
-                    placeholder="1"
-                  />
-                  <p className="text-xs text-gray-500 mt-1">
-                    Número de árboles de esta familia en el centro
-                  </p>
-                </div>
-
-                {/* Absorción CO2 Anual */}
-                <div>
-                  <Input
-                    id="absorcionCo2Anual"
-                    name="absorcionCo2Anual"
-                    label="Absorción CO2 Anual (kg/año)"
-                    type="number"
-                    step="0.01"
-                    min="0"
-                    value={formData.absorcionCo2Anual}
-                    onChange={handleChange}
-                    placeholder="Ej: 22.50"
-                  />
-                  <p className="text-xs text-gray-500 mt-1">
-                    Estimación de kg de CO2 absorbidos al año
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            {/* Botones de acción */}
-            <div className="flex gap-3 justify-end pt-6 border-t border-gray-200">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={handleCancel}
-                disabled={loading}
-              >
-                Cancelar
-              </Button>
-              <Button
-                type="submit"
-                variant="primary"
-                disabled={loading}
-              >
-                {loading
-                  ? (isEditMode ? 'Actualizando...' : 'Creando...')
-                  : (isEditMode ? 'Actualizar Árbol' : 'Crear Árbol')}
-              </Button>
-            </div>
-          </form>
-        </div>
+      <div className="flex justify-center items-center py-12">
+        <Spinner size="lg" text="Cargando datos..." />
       </div>
     );
   }
 
-  export default FormularioArbol;
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="max-w-3xl mx-auto">
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold text-gray-800">
+            {isEditMode ? 'Editar Árbol' : 'Nuevo Árbol'}
+          </h1>
+          <p className="text-gray-600 mt-1">
+            {isEditMode
+              ? 'Modifica los datos del árbol'
+              : 'Completa el formulario para añadir un nuevo árbol'}
+          </p>
+        </div>
+
+        {error && (
+          <div className="mb-4">
+            <Alert
+              type="error"
+              message={error}
+              onClose={() => setError('')}
+              dismissible
+            />
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow-md p-6">
+          {/* Sección: Información General */}
+          <div className="mb-6">
+            <h2 className="text-xl font-semibold text-gray-800 mb-4">Información General</h2>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {/* Nombre */}
+              <Input
+                id="nombre"
+                name="nombre"
+                label="Nombre del Árbol"
+                type="text"
+                value={formData.nombre}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                error={errors.nombre}
+                required
+                placeholder="Ej: Pino Canario del Patio"
+              />
+
+              {/* Especie */}
+              <Input
+                id="especie"
+                name="especie"
+                label="Especie"
+                type="text"
+                value={formData.especie}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                error={errors.especie}
+                required
+                placeholder="Ej: Pinus canariensis"
+              />
+
+              {/* Centro Educativo */}
+              <div>
+                <label htmlFor="centroEducativo" className="block text-sm font-medium text-gray-700 mb-1">
+                  Centro Educativo <span className="text-red-500">*</span>
+                </label>
+                <select
+                  id="centroEducativo"
+                  name="centroEducativo"
+                  value={formData.centroEducativo.id}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-brand-primary ${
+                    errors.centroEducativo ? 'border-red-500' : 'border-gray-300'
+                  }`}
+                  required
+                >
+                  <option value="">Selecciona un centro</option>
+                  {centrosFiltrados.map(centro => (
+                    <option key={centro.id} value={centro.id}>
+                      {centro.nombre}
+                    </option>
+                  ))}
+                </select>
+                {errors.centroEducativo && (
+                  <p className="mt-1 text-sm text-red-500">{errors.centroEducativo}</p>
+                )}
+              </div>
+
+              {/* Fecha de Plantación */}
+              <Input
+                id="fechaPlantacion"
+                name="fechaPlantacion"
+                label="Fecha de Plantación"
+                type="date"
+                value={formData.fechaPlantacion}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                error={errors.fechaPlantacion}
+                required
+              />
+
+              {/* Ubicación Específica */}
+              <div className="md:col-span-2">
+                <Input
+                  id="ubicacionEspecifica"
+                  name="ubicacionEspecifica"
+                  label="Ubicación Específica"
+                  type="text"
+                  value={formData.ubicacionEspecifica}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  placeholder="Ej: Patio principal, junto a la entrada"
+                />
+              </div>
+
+              {/* Cantidad */}
+              <div>
+                <Input
+                  id="cantidad"
+                  name="cantidad"
+                  label="Cantidad de árboles"
+                  type="number"
+                  min="1"
+                  value={formData.cantidad}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  error={errors.cantidad}
+                  required
+                  placeholder="1"
+                />
+                <p className="text-xs text-gray-500 mt-1">
+                  Número de árboles de esta familia en el centro
+                </p>
+              </div>
+
+              {/* Absorción CO2 Anual */}
+              <div>
+                <Input
+                  id="absorcionCo2Anual"
+                  name="absorcionCo2Anual"
+                  label="Absorción CO2 Anual (kg/año)"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={formData.absorcionCo2Anual}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  placeholder="Ej: 22.50"
+                />
+                <p className="text-xs text-gray-500 mt-1">
+                  Estimación de kg de CO2 absorbidos al año
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Botones de acción */}
+          <div className="flex gap-3 justify-end pt-6 border-t border-gray-200">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleCancel}
+              disabled={loading}
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={loading}
+            >
+              {loading
+                ? (isEditMode ? 'Actualizando...' : 'Creando...')
+                : (isEditMode ? 'Actualizar Árbol' : 'Crear Árbol')}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default FormularioArbol;

--- a/frontend/src/pages/arboles/ListadoArboles.jsx
+++ b/frontend/src/pages/arboles/ListadoArboles.jsx
@@ -1,295 +1,255 @@
-  import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { TreePine, Plus } from 'lucide-react';
-  import { useNavigate } from 'react-router-dom';
-  import { getArboles, getArbolesByCentro } from '../../services/arbolesService';
-  import { getCentros } from '../../services/centrosService';
-  import Button from '../../components/common/Button';
-  import Spinner from '../../components/common/Spinner';
-  import Alert from '../../components/common/Alert';
-  import { usePermissions } from '../../hooks/usePermissions';
-  import { useAuth } from '../../context/AuthContext';
+import { useNavigate } from 'react-router-dom';
+import { getArboles, getArbolesByCentro } from '../../services/arbolesService';
+import { getCentros } from '../../services/centrosService';
+import { useFetch } from '../../hooks/useFetch';
+import Button from '../../components/common/Button';
+import Spinner from '../../components/common/Spinner';
+import Alert from '../../components/common/Alert';
+import { usePermissions } from '../../hooks/usePermissions';
+import { useAuth } from '../../context/AuthContext';
 
-  function ListadoArboles() {
-    // Estados
-    const [arboles, setArboles] = useState([]);
-    const [centros, setCentros] = useState([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState('');
-    const [centroFiltro, setCentroFiltro] = useState('');
+function ListadoArboles() {
+  const { data, setData, loading, setLoading, error, setError } = useFetch(
+    () => Promise.all([getArboles(), getCentros()])
+  );
 
-    const navigate = useNavigate();
-    const { isAdmin, canCreateArbol } = usePermissions();
-    const { user } = useAuth();
+  const arboles = data?.[0] ?? [];
+  const centros = data?.[1] ?? [];
 
-    // Cargar árboles y centros al montar el componente
-    useEffect(() => {
-      cargarDatos();
-    }, []);
+  const [centroFiltro, setCentroFiltro] = useState('');
 
-    // Cargar datos iniciales
-    const cargarDatos = async () => {
-      try {
-        setLoading(true);
-        setError('');
+  const navigate = useNavigate();
+  const { isAdmin, canCreateArbol } = usePermissions();
+  const { user } = useAuth();
 
-        // Cargar árboles y centros en paralelo
-        const [arbolesData, centrosData] = await Promise.all([
-          getArboles(),
-          getCentros()
-        ]);
+  const handleFiltroChange = async (e) => {
+    const centroId = e.target.value;
+    setCentroFiltro(centroId);
 
-        setArboles(arbolesData);
-        setCentros(centrosData);
+    try {
+      setLoading(true);
+      setError('');
+      const arbolesData = centroId
+        ? await getArbolesByCentro(centroId)
+        : await getArboles();
+      setData(prev => [arbolesData, prev?.[1] ?? []]);
+    } catch (err) {
+      console.error('Error filtrando árboles:', err);
+      setError('Error al filtrar los árboles.');
+    } finally {
+      setLoading(false);
+    }
+  };
 
-      } catch (err) {
-        console.error('Error cargando datos:', err);
-        setError('No se pudo conectar con el servidor. Si es la primera carga, puede estar iniciándose (30-60 seg). Recarga la página en unos momentos.');
-      } finally {
-        setLoading(false);
-      }
-    };
+  const handleVerDetalle = (id) => navigate(`/arboles/${id}`);
+  const handleNuevoArbol = () => navigate('/arboles/nuevo');
 
-    // Manejar cambio de filtro por centro
-    const handleFiltroChange = async (e) => {
-      const centroId = e.target.value;
-      setCentroFiltro(centroId);
+  const formatearFecha = (fecha) => {
+    if (!fecha) return '-';
+    return new Date(fecha).toLocaleDateString('es-ES');
+  };
 
-      try {
-        setLoading(true);
-        setError('');
+  const mostrarBotonAnadir = user && (
+    isAdmin() || user.centros?.some(c => canCreateArbol(c.centroId))
+  );
 
-        let arbolesData;
-        if (centroId === '') {
-          arbolesData = await getArboles();
-        } else {
-          arbolesData = await getArbolesByCentro(centroId);
-        }
-
-        setArboles(arbolesData);
-      } catch (err) {
-        console.error('Error filtrando árboles:', err);
-        setError('Error al filtrar los árboles.');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    // Navegar al detalle de un árbol
-    const handleVerDetalle = (id) => {
-      navigate(`/arboles/${id}`);
-    };
-
-    // Navegar al formulario de crear árbol
-    const handleNuevoArbol = () => {
-      navigate('/arboles/nuevo');
-    };
-
-    // Formatear fecha para mostrar
-    const formatearFecha = (fecha) => {
-      if (!fecha) return '-';
-      return new Date(fecha).toLocaleDateString('es-ES');
-    };
-
-    // Mostrar botón "Añadir" solo si el usuario tiene permisos
-    const mostrarBotonAnadir = user && (
-      isAdmin() || user.centros?.some(c => canCreateArbol(c.centroId))
-    );
-
-    return (
-      <div className="container mx-auto px-4 py-8">
-        <div className="mb-6">
-          <h1 className="text-3xl font-bold text-brand-primary mb-2 flex items-center gap-3">
-              <TreePine className="w-8 h-8 text-brand-secondary shrink-0" />
-              Gestión de Árboles
-            </h1>
-          <p className="text-gray-600">Listado de árboles monitorizados en centros educativos</p>
-        </div>
-
-        {/* Barra de acciones y filtros */}
-        <div className="mb-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-          {/* Filtro por centro */}
-          <div className="flex items-center gap-2">
-            <label htmlFor="filtro-centro" className="text-sm font-medium text-gray-700">
-              Filtrar por centro:
-            </label>
-            <select
-              id="filtro-centro"
-              value={centroFiltro}
-              onChange={handleFiltroChange}
-              className="border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-primary"
-            >
-              <option value="">Todos los centros</option>
-              {centros.map((centro) => (
-                <option key={centro.id} value={centro.id}>
-                  {centro.nombre}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          {/* Botón añadir árbol */}
-          {mostrarBotonAnadir && (
-          <Button
-            variant="primary"
-            onClick={handleNuevoArbol}
-          >
-            <Plus className="w-4 h-4 mr-1 inline" /> Añadir Árbol
-          </Button> )}
-        </div>
-
-        {/* Mensaje de error */}
-        {error && (
-          <div className="mb-4">
-            <Alert
-              type="error"
-              message={error}
-              onClose={() => setError('')}
-              dismissible
-            />
-          </div>
-        )}
-
-        {/* Loading spinner */}
-        {loading ? (
-          <div className="flex justify-center items-center py-12">
-            <Spinner size="lg" text="Cargando árboles..." />
-          </div>
-        ) : (
-          <>
-            {/* Tabla de árboles */}
-            {arboles.length === 0 ? (
-              <div className="bg-white rounded-lg shadow p-8 text-center">
-                <p className="text-gray-500 text-lg">
-                  {centroFiltro
-                    ? 'No hay árboles en este centro educativo.'
-                    : 'No hay árboles registrados. Añade el primero.'}
-                </p>
-              </div>
-            ) : (
-              <div className="bg-white rounded-lg shadow overflow-hidden">
-                {/* Tabla - versión desktop */}
-                <div className="hidden md:block overflow-x-auto">
-                  <table className="min-w-full divide-y divide-brand-bg-green">
-                    <thead className="bg-brand-primary">
-                      <tr>
-                        <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
-                          ID
-                        </th>
-                        <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
-                          Nombre
-                        </th>
-                        <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
-                          Especie
-                        </th>
-                        <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
-                          Centro Educativo
-                        </th>
-                        <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
-                          Fecha Plantación
-                        </th>
-                        <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
-                          Acciones
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody className="bg-white divide-y divide-brand-bg-green">
-                      {arboles.map((arbol) => (
-                        <tr
-                          key={arbol.id}
-                          className="hover:bg-brand-primary/5 cursor-pointer transition-colors"
-                          onClick={() => handleVerDetalle(arbol.id)}
-                        >
-                          <td className="px-6 py-4 whitespace-nowrap">
-                            <div className="text-sm font-medium text-gray-600">#{arbol.id}</div>
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap">
-                            <div className="text-sm font-medium text-gray-900">{arbol.nombre}</div>
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap">
-                            <div className="text-sm text-gray-500">{arbol.especie}</div>
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap">
-                            <div className="text-sm text-gray-500">
-                              {arbol.centroEducativo?.nombre || '-'}
-                            </div>
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap">
-                            <div className="text-sm text-gray-500">
-                              {formatearFecha(arbol.fechaPlantacion)}
-                            </div>
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm">
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleVerDetalle(arbol.id);
-                              }}
-                            >
-                              Ver Detalle
-                            </Button>
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-
-                {/* Cards - versión mobile */}
-                <div className="md:hidden">
-                  {arboles.map((arbol) => (
-                    <div
-                      key={arbol.id}
-                      onClick={() => handleVerDetalle(arbol.id)}
-                      className="p-4 border-b border-gray-200 hover:bg-brand-primary/5 cursor-pointer transition-colors"
-                    >
-                      <div className="flex justify-between items-start mb-2">
-                        <div className="flex items-center gap-2">
-                          <h3 className="text-lg font-semibold text-gray-900">{arbol.nombre}</h3>
-                          <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-brand-bg-green text-brand-primary">
-                            #{arbol.id}
-                          </span>
-                        </div>
-                      </div>
-                      <p className="text-sm text-gray-600 mb-1">
-                        <span className="font-medium">Especie:</span> {arbol.especie}
-                      </p>
-                      <p className="text-sm text-gray-600 mb-1">
-                        <span className="font-medium">Centro:</span>{' '}
-                        {arbol.centroEducativo?.nombre || '-'}
-                      </p>
-                      <p className="text-sm text-gray-600 mb-3">
-                        <span className="font-medium">Plantación:</span>{' '}
-                        {formatearFecha(arbol.fechaPlantacion)}
-                      </p>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        fullWidth
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleVerDetalle(arbol.id);
-                        }}
-                      >
-                        Ver Detalle
-                      </Button>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Contador de resultados */}
-            {arboles.length > 0 && (
-              <div className="mt-4 text-center text-sm text-gray-600">
-                Mostrando {arboles.length} {arboles.length === 1 ? 'árbol' : 'árboles'}
-              </div>
-            )}
-          </>
-        )}
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mb-6">
+        <h1 className="text-3xl font-bold text-brand-primary mb-2 flex items-center gap-3">
+            <TreePine className="w-8 h-8 text-brand-secondary shrink-0" />
+            Gestión de Árboles
+          </h1>
+        <p className="text-gray-600">Listado de árboles monitorizados en centros educativos</p>
       </div>
-    );
-  }
 
-  export default ListadoArboles;
+      {/* Barra de acciones y filtros */}
+      <div className="mb-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        {/* Filtro por centro */}
+        <div className="flex items-center gap-2">
+          <label htmlFor="filtro-centro" className="text-sm font-medium text-gray-700">
+            Filtrar por centro:
+          </label>
+          <select
+            id="filtro-centro"
+            value={centroFiltro}
+            onChange={handleFiltroChange}
+            className="border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-primary"
+          >
+            <option value="">Todos los centros</option>
+            {centros.map((centro) => (
+              <option key={centro.id} value={centro.id}>
+                {centro.nombre}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Botón añadir árbol */}
+        {mostrarBotonAnadir && (
+        <Button
+          variant="primary"
+          onClick={handleNuevoArbol}
+        >
+          <Plus className="w-4 h-4 mr-1 inline" /> Añadir Árbol
+        </Button> )}
+      </div>
+
+      {/* Mensaje de error */}
+      {error && (
+        <div className="mb-4">
+          <Alert
+            type="error"
+            message={error}
+            onClose={() => setError('')}
+            dismissible
+          />
+        </div>
+      )}
+
+      {/* Loading spinner */}
+      {loading ? (
+        <div className="flex justify-center items-center py-12">
+          <Spinner size="lg" text="Cargando árboles..." />
+        </div>
+      ) : (
+        <>
+          {/* Tabla de árboles */}
+          {arboles.length === 0 ? (
+            <div className="bg-white rounded-lg shadow p-8 text-center">
+              <p className="text-gray-500 text-lg">
+                {centroFiltro
+                  ? 'No hay árboles en este centro educativo.'
+                  : 'No hay árboles registrados. Añade el primero.'}
+              </p>
+            </div>
+          ) : (
+            <div className="bg-white rounded-lg shadow overflow-hidden">
+              {/* Tabla - versión desktop */}
+              <div className="hidden md:block overflow-x-auto">
+                <table className="min-w-full divide-y divide-brand-bg-green">
+                  <thead className="bg-brand-primary">
+                    <tr>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
+                        ID
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
+                        Nombre
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
+                        Especie
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
+                        Centro Educativo
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
+                        Fecha Plantación
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
+                        Acciones
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-brand-bg-green">
+                    {arboles.map((arbol) => (
+                      <tr
+                        key={arbol.id}
+                        className="hover:bg-brand-primary/5 cursor-pointer transition-colors"
+                        onClick={() => handleVerDetalle(arbol.id)}
+                      >
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <div className="text-sm font-medium text-gray-600">#{arbol.id}</div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <div className="text-sm font-medium text-gray-900">{arbol.nombre}</div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <div className="text-sm text-gray-500">{arbol.especie}</div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <div className="text-sm text-gray-500">
+                            {arbol.centroEducativo?.nombre || '-'}
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <div className="text-sm text-gray-500">
+                            {formatearFecha(arbol.fechaPlantacion)}
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleVerDetalle(arbol.id);
+                            }}
+                          >
+                            Ver Detalle
+                          </Button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {/* Cards - versión mobile */}
+              <div className="md:hidden">
+                {arboles.map((arbol) => (
+                  <div
+                    key={arbol.id}
+                    onClick={() => handleVerDetalle(arbol.id)}
+                    className="p-4 border-b border-gray-200 hover:bg-brand-primary/5 cursor-pointer transition-colors"
+                  >
+                    <div className="flex justify-between items-start mb-2">
+                      <div className="flex items-center gap-2">
+                        <h3 className="text-lg font-semibold text-gray-900">{arbol.nombre}</h3>
+                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-brand-bg-green text-brand-primary">
+                          #{arbol.id}
+                        </span>
+                      </div>
+                    </div>
+                    <p className="text-sm text-gray-600 mb-1">
+                      <span className="font-medium">Especie:</span> {arbol.especie}
+                    </p>
+                    <p className="text-sm text-gray-600 mb-1">
+                      <span className="font-medium">Centro:</span>{' '}
+                      {arbol.centroEducativo?.nombre || '-'}
+                    </p>
+                    <p className="text-sm text-gray-600 mb-3">
+                      <span className="font-medium">Plantación:</span>{' '}
+                      {formatearFecha(arbol.fechaPlantacion)}
+                    </p>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      fullWidth
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleVerDetalle(arbol.id);
+                      }}
+                    >
+                      Ver Detalle
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Contador de resultados */}
+          {arboles.length > 0 && (
+            <div className="mt-4 text-center text-sm text-gray-600">
+              Mostrando {arboles.length} {arboles.length === 1 ? 'árbol' : 'árboles'}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export default ListadoArboles;

--- a/frontend/src/pages/centros/ListadoCentros.jsx
+++ b/frontend/src/pages/centros/ListadoCentros.jsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react';
 import { School, Plus } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { getCentros } from '../../services/centrosService';
+import { useFetch } from '../../hooks/useFetch';
 import Button from '../../components/common/Button';
 import Spinner from '../../components/common/Spinner';
 import Alert from '../../components/common/Alert';
@@ -9,46 +9,15 @@ import { usePermissions } from '../../hooks/usePermissions';
 import { ISLAS } from '../../constants/islas';
 
 function ListadoCentros() {
-  // Estados
-  const [centros, setCentros] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
+  const { data, loading, error, setError } = useFetch(getCentros);
+  const centros = data ?? [];
 
   const navigate = useNavigate();
   const { isAdmin } = usePermissions();
 
-  // Cargar centros al montar el componente
-  useEffect(() => {
-    cargarCentros();
-  }, []);
+  const handleVerDetalle = (id) => navigate(`/centros/${id}`);
+  const handleNuevoCentro = () => navigate('/centros/nuevo');
 
-  // Cargar datos
-  const cargarCentros = async () => {
-    try {
-      setLoading(true);
-      setError('');
-
-      const centrosData = await getCentros();
-      setCentros(centrosData);
-    } catch (err) {
-      console.error('Error cargando centros:', err);
-      setError('No se pudo conectar con el servidor. Si es la primera carga, puede estar iniciándose (30-60 seg). Recarga la página en unos momentos.');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // Navegar al detalle de un centro
-  const handleVerDetalle = (id) => {
-    navigate(`/centros/${id}`);
-  };
-
-  // Navegar al formulario de crear centro
-  const handleNuevoCentro = () => {
-    navigate('/centros/nuevo');
-  };
-
-  // Formatear fecha para mostrar
   const formatearFecha = (fecha) => {
     if (!fecha) return '-';
     return new Date(fecha).toLocaleDateString('es-ES');

--- a/frontend/src/pages/dispositivos/FormularioDispositivo.jsx
+++ b/frontend/src/pages/dispositivos/FormularioDispositivo.jsx
@@ -2,12 +2,32 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { getDispositivoById, createDispositivo, updateDispositivo } from '../../services/dispositivosService';
 import { getCentros } from '../../services/centrosService';
+import { useForm } from '../../hooks/useForm';
 import Input from '../../components/common/Input';
 import Button from '../../components/common/Button';
 import Spinner from '../../components/common/Spinner';
 import Alert from '../../components/common/Alert';
 import { usePermissions } from '../../hooks/usePermissions';
 import { useAuth } from '../../context/AuthContext';
+
+const macRegex = /^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$/;
+
+const validarDispositivo = (values) => {
+  const errors = {};
+  if (!values.macAddress.trim()) {
+    errors.macAddress = 'La dirección MAC es obligatoria';
+  } else if (!macRegex.test(values.macAddress.trim())) {
+    errors.macAddress = 'Formato incorrecto. Usa XX:XX:XX:XX:XX:XX';
+  }
+  if (!values.centroEducativo?.id) {
+    errors.centroEducativo = 'Debes seleccionar un centro educativo';
+  }
+  const freq = parseInt(values.frecuenciaLecturaSeg);
+  if (isNaN(freq) || freq < 5 || freq > 3600) {
+    errors.frecuenciaLecturaSeg = 'La frecuencia debe estar entre 5 y 3600 segundos';
+  }
+  return errors;
+};
 
 function FormularioDispositivo() {
   const { id } = useParams();
@@ -16,7 +36,7 @@ function FormularioDispositivo() {
   const isEditMode = Boolean(id);
 
   const centroIdDesdeState = location.state?.centroId;
-  const [formData, setFormData] = useState({
+  const initialValues = {
     macAddress: '',
     centroEducativo: { id: centroIdDesdeState || '' },
     activo: true,
@@ -27,13 +47,26 @@ function FormularioDispositivo() {
     umbralHumedadAmbienteMax: '',
     umbralHumedadSueloMin: '',
     umbralCO2Max: '',
-  });
+  };
+
+  const {
+    values: formData,
+    setValues: setFormData,
+    errors,
+    setErrors,
+    handleChange,
+    handleBlur,
+    validateAll,
+  } = useForm(
+    initialValues,
+    validarDispositivo,
+    { centroEducativo: (v) => ({ id: v }) }
+  );
 
   const [centros, setCentros] = useState([]);
   const [loading, setLoading] = useState(false);
   const [loadingData, setLoadingData] = useState(isEditMode);
   const [error, setError] = useState('');
-  const [errors, setErrors] = useState({});
   const { isAdmin } = usePermissions();
   const { user } = useAuth();
 
@@ -74,52 +107,10 @@ function FormularioDispositivo() {
     }
   };
 
-  const handleChange = (e) => {
-    const { name, value, type, checked } = e.target;
-
-    if (name === 'centroEducativo') {
-      setFormData(prev => ({ ...prev, centroEducativo: { id: value } }));
-    } else if (type === 'checkbox') {
-      setFormData(prev => ({ ...prev, [name]: checked }));
-    } else {
-      setFormData(prev => ({ ...prev, [name]: value }));
-    }
-
-    if (errors[name]) {
-      setErrors(prev => ({ ...prev, [name]: '' }));
-    }
-  };
-
-  const validarFormulario = () => {
-    const nuevosErrores = {};
-
-    if (!formData.macAddress.trim()) {
-      nuevosErrores.macAddress = 'La dirección MAC es obligatoria';
-    } else {
-      // Formato MAC: XX:XX:XX:XX:XX:XX
-      const macRegex = /^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$/;
-      if (!macRegex.test(formData.macAddress.trim())) {
-        nuevosErrores.macAddress = 'Formato incorrecto. Usa XX:XX:XX:XX:XX:XX';
-      }
-    }
-
-    if (!formData.centroEducativo.id) {
-      nuevosErrores.centroEducativo = 'Debes seleccionar un centro educativo';
-    }
-
-    const freq = parseInt(formData.frecuenciaLecturaSeg);
-    if (isNaN(freq) || freq < 5 || freq > 3600) {
-      nuevosErrores.frecuenciaLecturaSeg = 'La frecuencia debe estar entre 5 y 3600 segundos';
-    }
-
-    setErrors(nuevosErrores);
-    return Object.keys(nuevosErrores).length === 0;
-  };
-
   const handleSubmit = async (e) => {
     e.preventDefault();
 
-    if (!validarFormulario()) {
+    if (!validateAll()) {
       setError('Por favor, corrige los errores en el formulario');
       return;
     }
@@ -147,7 +138,7 @@ function FormularioDispositivo() {
       } else {
         const nuevo = await createDispositivo(dataToSend);
         navigate(`/centros/${nuevo.centroEducativo.id}`, {
-          state: { mensaje: 'Dispositivo registrado correctamente' }
+          state: { mensaje: 'Dispositivo registrado correctamente' },
         });
       }
     } catch (err) {
@@ -164,9 +155,7 @@ function FormularioDispositivo() {
     }
   };
 
-  const handleCancel = () => {
-    navigate(-1);
-  };
+  const handleCancel = () => navigate(-1);
 
   if (loadingData) {
     return (
@@ -201,90 +190,105 @@ function FormularioDispositivo() {
           </div>
         )}
 
-        <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow-md p-6">
-          <div className="space-y-5">
-            {/* Dirección MAC */}
-            <Input
-              id="macAddress"
-              name="macAddress"
-              label="Dirección MAC"
-              type="text"
-              value={formData.macAddress}
-              onChange={handleChange}
-              error={errors.macAddress}
-              required
-              placeholder="Ej: AA:BB:CC:DD:EE:FF"
-            />
-            <p className="text-xs text-gray-500 -mt-3">
-              Dirección MAC del chip ESP32 (visible en el monitor serie)
-            </p>
+        <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow-md p-6 space-y-6">
 
-            {/* Centro Educativo */}
-            <div>
-              <label htmlFor="centroEducativo" className="block text-sm font-medium text-gray-700 mb-1">
-                Centro Educativo <span className="text-red-500">*</span>
-              </label>
-              <select
-                id="centroEducativo"
-                name="centroEducativo"
-                value={formData.centroEducativo.id}
-                onChange={handleChange}
-                className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-brand-primary ${
-                  errors.centroEducativo ? 'border-red-500' : 'border-gray-300'
-                }`}
-                required
-              >
-                <option value="">Selecciona un centro</option>
-                {centrosFiltrados.map(centro => (
-                  <option key={centro.id} value={centro.id}>
-                    {centro.nombre}
-                  </option>
-                ))}
-              </select>
-              {errors.centroEducativo && (
-                <p className="mt-1 text-sm text-red-500">{errors.centroEducativo}</p>
-              )}
-            </div>
+          {/* Datos básicos */}
+          <fieldset className="border border-gray-200 rounded-lg p-5">
+            <legend className="px-2 text-base font-semibold text-gray-700">
+              Datos básicos
+            </legend>
 
-            {/* Frecuencia de lectura */}
-            <div>
-              <Input
-                id="frecuenciaLecturaSeg"
-                name="frecuenciaLecturaSeg"
-                label="Frecuencia de lectura (segundos)"
-                type="number"
-                min="5"
-                max="3600"
-                value={formData.frecuenciaLecturaSeg}
-                onChange={handleChange}
-                error={errors.frecuenciaLecturaSeg}
-                required
-              />
-              <p className="text-xs text-gray-500 mt-1">
-                Intervalo entre lecturas. Mínimo 5 s, máximo 3600 s (1 hora).
-              </p>
-            </div>
+            <div className="space-y-5 mt-2">
+              {/* Dirección MAC */}
+              <div>
+                <Input
+                  id="macAddress"
+                  name="macAddress"
+                  label="Dirección MAC"
+                  type="text"
+                  value={formData.macAddress}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  error={errors.macAddress}
+                  required
+                  placeholder="Ej: AA:BB:CC:DD:EE:FF"
+                />
+                <p className="text-xs text-gray-500 mt-1">
+                  Dirección MAC del chip ESP32 (visible en el monitor serie)
+                </p>
+              </div>
 
-            {/* Estado activo */}
-            <div className="flex items-center gap-3">
-              <input
-                id="activo"
-                name="activo"
-                type="checkbox"
-                checked={formData.activo}
-                onChange={handleChange}
-                className="h-4 w-4 rounded border-gray-300 text-brand-primary focus:ring-brand-primary"
-              />
-              <label htmlFor="activo" className="text-sm font-medium text-gray-700">
-                Dispositivo activo
-              </label>
+              {/* Centro Educativo */}
+              <div>
+                <label htmlFor="centroEducativo" className="block text-sm font-medium text-gray-700 mb-1">
+                  Centro Educativo <span className="text-red-500">*</span>
+                </label>
+                <select
+                  id="centroEducativo"
+                  name="centroEducativo"
+                  value={formData.centroEducativo.id}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-brand-primary ${
+                    errors.centroEducativo ? 'border-red-500' : 'border-gray-300'
+                  }`}
+                  required
+                >
+                  <option value="">Selecciona un centro</option>
+                  {centrosFiltrados.map(centro => (
+                    <option key={centro.id} value={centro.id}>
+                      {centro.nombre}
+                    </option>
+                  ))}
+                </select>
+                {errors.centroEducativo && (
+                  <p className="mt-1 text-sm text-red-500">{errors.centroEducativo}</p>
+                )}
+              </div>
+
+              {/* Frecuencia de lectura */}
+              <div>
+                <Input
+                  id="frecuenciaLecturaSeg"
+                  name="frecuenciaLecturaSeg"
+                  label="Frecuencia de lectura (segundos)"
+                  type="number"
+                  min="5"
+                  max="3600"
+                  value={formData.frecuenciaLecturaSeg}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  error={errors.frecuenciaLecturaSeg}
+                  required
+                />
+                <p className="text-xs text-gray-500 mt-1">
+                  Intervalo entre lecturas. Mínimo 5 s, máximo 3600 s (1 hora).
+                </p>
+              </div>
+
+              {/* Estado activo */}
+              <div className="flex items-center gap-3">
+                <input
+                  id="activo"
+                  name="activo"
+                  type="checkbox"
+                  checked={formData.activo}
+                  onChange={handleChange}
+                  className="h-4 w-4 rounded border-gray-300 text-brand-primary focus:ring-brand-primary"
+                />
+                <label htmlFor="activo" className="text-sm font-medium text-gray-700">
+                  Dispositivo activo
+                </label>
+              </div>
             </div>
-          </div>
+          </fieldset>
 
           {/* Umbrales de Monitorización */}
-          <div className="pt-6 mt-6 border-t border-gray-200">
-            <h2 className="text-lg font-semibold text-gray-800 mb-1">Umbrales de Monitorización</h2>
-            <p className="text-sm text-gray-500 mb-4">
+          <fieldset className="border border-gray-200 rounded-lg p-5">
+            <legend className="px-2 text-base font-semibold text-gray-700">
+              Umbrales de Monitorización
+            </legend>
+            <p className="text-sm text-gray-500 mt-2 mb-4">
               El sistema generará alertas cuando los valores del sensor superen estos rangos.
             </p>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -296,6 +300,7 @@ function FormularioDispositivo() {
                 step="0.1"
                 value={formData.umbralTempMin}
                 onChange={handleChange}
+                onBlur={handleBlur}
                 placeholder="Ej: 5"
               />
               <Input
@@ -306,6 +311,7 @@ function FormularioDispositivo() {
                 step="0.1"
                 value={formData.umbralTempMax}
                 onChange={handleChange}
+                onBlur={handleBlur}
                 placeholder="Ej: 40"
               />
               <Input
@@ -316,6 +322,7 @@ function FormularioDispositivo() {
                 step="0.1"
                 value={formData.umbralHumedadAmbienteMin}
                 onChange={handleChange}
+                onBlur={handleBlur}
                 placeholder="Ej: 30"
               />
               <Input
@@ -326,6 +333,7 @@ function FormularioDispositivo() {
                 step="0.1"
                 value={formData.umbralHumedadAmbienteMax}
                 onChange={handleChange}
+                onBlur={handleBlur}
                 placeholder="Ej: 90"
               />
               <Input
@@ -336,6 +344,7 @@ function FormularioDispositivo() {
                 step="0.1"
                 value={formData.umbralHumedadSueloMin}
                 onChange={handleChange}
+                onBlur={handleBlur}
                 placeholder="Ej: 30"
               />
               <Input
@@ -346,13 +355,14 @@ function FormularioDispositivo() {
                 step="1"
                 value={formData.umbralCO2Max}
                 onChange={handleChange}
+                onBlur={handleBlur}
                 placeholder="Ej: 1000"
               />
             </div>
-          </div>
+          </fieldset>
 
           {/* Botones de acción */}
-          <div className="flex gap-3 justify-end pt-6 mt-6 border-t border-gray-200">
+          <div className="flex gap-3 justify-end pt-2">
             <Button
               type="button"
               variant="outline"

--- a/frontend/src/pages/usuarios/ListadoUsuarios.jsx
+++ b/frontend/src/pages/usuarios/ListadoUsuarios.jsx
@@ -1,43 +1,19 @@
-import { useState, useEffect } from 'react';
 import { Plus, Users } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { getUsuarios } from '../../services/usuariosService';
+import { useFetch } from '../../hooks/useFetch';
 import Button from '../../components/common/Button';
 import Spinner from '../../components/common/Spinner';
 import Alert from '../../components/common/Alert';
 
 function ListadoUsuarios() {
-  const [usuarios, setUsuarios] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
+  const { data, loading, error, setError } = useFetch(getUsuarios);
+  const usuarios = data ?? [];
 
   const navigate = useNavigate();
 
-  useEffect(() => {
-    cargarUsuarios();
-  }, []);
-
-  const cargarUsuarios = async () => {
-    try {
-      setLoading(true);
-      setError('');
-      const data = await getUsuarios();
-      setUsuarios(data);
-    } catch (err) {
-      console.error('Error cargando usuarios:', err);
-      setError('No se pudo conectar con el servidor. Si es la primera carga, puede estar iniciándose (30-60 seg). Recarga la página en unos momentos.');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleVerDetalle = (id) => {
-    navigate(`/usuarios/${id}`);
-  };
-
-  const handleNuevoUsuario = () => {
-    navigate('/usuarios/nuevo');
-  };
+  const handleVerDetalle = (id) => navigate(`/usuarios/${id}`);
+  const handleNuevoUsuario = () => navigate('/usuarios/nuevo');
 
   return (
     <div className="container mx-auto px-4 py-8">


### PR DESCRIPTION
## Summary

- **`useFetch`**: hook genérico que elimina la duplicación de `loading/error/data` en los tres listados (ListadoArboles, ListadoCentros, ListadoUsuarios)
- **`useForm`**: hook para formularios con `touched` por campo, validación en tiempo real tras primer blur y soporte de `transforms` para valores anidados (`centroEducativo`)
- **`Input.jsx`**: estado `touched` interno — borde verde tras validación correcta, rojo en error, con `transition-colors`
- **`FormularioDispositivo`**: separación visual con `<fieldset>` + `<legend>` para datos básicos vs umbrales de monitorización
- **`frontend/README.md`**: secciones nuevas — Decisiones técnicas, Arquitectura de componentes (Mermaid), Guía de desarrollo CRUD paso a paso, y Tests

## Archivos modificados

- `frontend/src/hooks/useFetch.js` (nuevo)
- `frontend/src/hooks/useForm.js` (nuevo)
- `frontend/src/components/common/Input.jsx`
- `frontend/src/pages/arboles/FormularioArbol.jsx`
- `frontend/src/pages/arboles/ListadoArboles.jsx`
- `frontend/src/pages/centros/ListadoCentros.jsx`
- `frontend/src/pages/dispositivos/FormularioDispositivo.jsx`
- `frontend/src/pages/usuarios/ListadoUsuarios.jsx`
- `frontend/README.md`

## Test plan

- [ ] `npm run build` pasa sin errores (verificado: 3.02 s, 0 errores)
- [ ] Login → navegar a Listado de Árboles, Centros y Usuarios: spinner aparece y datos cargan
- [ ] Crear/editar árbol: dejar campo vacío y hacer blur → error en tiempo real; corregirlo → borde verde
- [ ] Crear/editar dispositivo: verificar agrupación visual fieldset básicos / umbrales
- [ ] Submit con campos vacíos → todos los errores aparecen simultáneamente