### PR TITLE
feat(android): add help screen with expandable FAQ sections

### DIFF
--- a/android/app/src/main/java/com/example/proyectoarboles/activities/MainActivity.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/activities/MainActivity.java
@@ -19,6 +19,7 @@ import com.example.proyectoarboles.fragments.HistoricoDispositivoFragment;
 import com.example.proyectoarboles.fragments.DetalleUsuarioFragment;
 import com.example.proyectoarboles.fragments.FormularioUsuarioFragment;
 import com.example.proyectoarboles.fragments.ListarCentrosFragment;
+import com.example.proyectoarboles.fragments.AyudaFragment;
 import com.example.proyectoarboles.fragments.LoginFragment;
 import com.example.proyectoarboles.fragments.RegistrerFragment;
 import com.example.proyectoarboles.model.Usuario;
@@ -54,6 +55,9 @@ public class MainActivity extends AppCompatActivity {
                 return true;
             } else if (itemId == R.id.menu_usuarios) {
                 showFragment(new AdminUsuariosFragment());
+                return true;
+            } else if (itemId == R.id.menu_ayuda) {
+                showFragment(new AyudaFragment());
                 return true;
             } else if (itemId == R.id.menu_login) {
                 if (permissionManager.isLoggedIn()) {
@@ -135,6 +139,11 @@ public class MainActivity extends AppCompatActivity {
     public void navigateToDetalleCentro(long centroId) {
         showFragment(DetalleCentroFragment.newInstance(centroId));
         setNavSelected(R.id.menu_centros);
+    }
+
+    public void navigateToAyuda() {
+        showFragment(new AyudaFragment());
+        setNavSelected(R.id.menu_ayuda);
     }
 
     public void navigateToLogin() {

--- a/android/app/src/main/java/com/example/proyectoarboles/fragments/AyudaFragment.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/fragments/AyudaFragment.java
@@ -1,0 +1,171 @@
+package com.example.proyectoarboles.fragments;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.example.proyectoarboles.R;
+
+public class AyudaFragment extends Fragment {
+
+    private static class Seccion {
+        final String titulo;
+        final String[][] items;
+
+        Seccion(String titulo, String[][] items) {
+            this.titulo = titulo;
+            this.items = items;
+        }
+    }
+
+    private static final Seccion[] SECCIONES = {
+        new Seccion("Inicio de sesión y registro", new String[][] {
+            {
+                "¿Cómo inicio sesión?",
+                "Introduce tu email y contraseña en la pantalla Login y pulsa «Iniciar Sesión». Si tus credenciales son correctas accederás al Inicio."
+            },
+            {
+                "Mensajes de error habituales al iniciar sesión",
+                "• «Email y contraseña son requeridos» — Rellena ambos campos.\n" +
+                "• «Credenciales incorrectas» — Verifica email y contraseña.\n" +
+                "• «Error de conexión. Inténtalo de nuevo.» — El servidor puede estar arrancando (cold start). Espera 30-60 segundos y vuelve a intentarlo."
+            },
+            {
+                "¿Cómo me registro?",
+                "Pulsa «Registrarse» desde la pantalla de login. Completa nombre, email y contraseña. Si el registro es correcto, la app inicia sesión automáticamente. Los nuevos usuarios tienen rol COORDINADOR por defecto."
+            },
+        }),
+        new Seccion("Navegación", new String[][] {
+            {
+                "¿Cómo navego por la app?",
+                "En vertical (portrait) usa la barra inferior con Inicio, Centros, Usuarios (solo ADMIN) y Login/Logout. En horizontal (landscape) la navegación aparece como rail lateral con las mismas opciones."
+            },
+            {
+                "No veo la sección «Usuarios»",
+                "La sección Usuarios solo es visible para cuentas con rol ADMIN. Si eres COORDINADOR no tienes acceso a la gestión de usuarios."
+            },
+        }),
+        new Seccion("Pantalla Inicio (Dashboard)", new String[][] {
+            {
+                "¿Qué muestra el Inicio?",
+                "• Número de centros educativos.\n" +
+                "• Total de árboles plantados.\n" +
+                "• Número de dispositivos activos.\n" +
+                "• CO₂ total anual estimado.\n" +
+                "• Si hay sesión activa, se muestra tu nombre y rol.\n" +
+                "• Botón para ir al listado de centros."
+            },
+            {
+                "Los datos no se cargan",
+                "El servidor puede estar arrancando tras un periodo de inactividad (cold start en Render). Espera 30-60 segundos y vuelve a la pantalla."
+            },
+        }),
+        new Seccion("Centros educativos", new String[][] {
+            {
+                "¿Cómo veo los centros?",
+                "Pulsa «Centros» en la navegación. Verás el listado con nombre, población e isla. Pulsa un centro para ver su detalle con árboles y dispositivos."
+            },
+            {
+                "¿Cómo creo o edito un centro?",
+                "Necesitas rol ADMIN o COORDINADOR. Desde el listado pulsa el botón de nuevo centro. Para editar, entra al detalle y usa el botón de edición."
+            },
+        }),
+        new Seccion("Árboles", new String[][] {
+            {
+                "¿Dónde gestiono los árboles?",
+                "Los árboles se gestionan desde el detalle de cada centro educativo. Ve a Centros → selecciona un centro → sección de árboles."
+            },
+            {
+                "¿Qué información tiene el detalle de un árbol?",
+                "Nombre común y científico, especie, cantidad de ejemplares, fecha de plantación y absorción de CO₂ anual estimada."
+            },
+            {
+                "¿Cómo creo o edito un árbol?",
+                "Necesitas rol ADMIN o COORDINADOR. Desde el detalle del centro pulsa «Añadir árbol». Para editar, entra al detalle del árbol y usa el botón de edición."
+            },
+        }),
+        new Seccion("Dispositivos IoT", new String[][] {
+            {
+                "¿Qué es un dispositivo IoT?",
+                "Es un sensor ESP32 instalado en un centro que mide temperatura, humedad, CO₂, humedad del suelo y luz. Los datos se envían automáticamente al sistema."
+            },
+            {
+                "¿Cómo veo las lecturas de un dispositivo?",
+                "Ve al detalle del centro → sección Dispositivos → pulsa el dispositivo → «Ver histórico». Podrás filtrar por periodo y ver las gráficas de evolución."
+            },
+            {
+                "¿Cómo registro un nuevo dispositivo?",
+                "Necesitas rol ADMIN o COORDINADOR. Desde el detalle del centro pulsa «Añadir dispositivo». Introduce el nombre y la dirección MAC del ESP32."
+            },
+        }),
+        new Seccion("Alertas", new String[][] {
+            {
+                "¿Qué es una alerta?",
+                "Una alerta se genera automáticamente cuando una lectura de un sensor supera el umbral configurado. Puede tener estado ACTIVA o RESUELTA."
+            },
+            {
+                "¿Dónde veo las alertas?",
+                "Las alertas aparecen en el detalle del dispositivo. Cada alerta muestra el sensor afectado, el valor registrado y la fecha."
+            },
+        }),
+        new Seccion("Preguntas frecuentes", new String[][] {
+            {
+                "¿Por qué la app tarda en cargar la primera vez?",
+                "El servidor backend está en Render con plan gratuito. Tras un tiempo sin uso entra en reposo. La primera carga puede tardar 30-60 segundos. Espera y vuelve a intentarlo."
+            },
+            {
+                "¿Qué rol tengo al registrarme?",
+                "Los nuevos usuarios se registran como COORDINADOR. Solo un administrador puede elevar una cuenta a ADMIN."
+            },
+            {
+                "¿Qué versión de Android necesito?",
+                "Android 7.0 o superior (API 24)."
+            },
+        }),
+    };
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater,
+                             @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_ayuda, container, false);
+        LinearLayout contenedor = view.findViewById(R.id.container_secciones);
+
+        for (Seccion seccion : SECCIONES) {
+            View seccionView = inflater.inflate(R.layout.item_ayuda_seccion, contenedor, false);
+
+            TextView tvTitulo = seccionView.findViewById(R.id.tv_titulo_seccion);
+            LinearLayout header = seccionView.findViewById(R.id.header_seccion);
+            LinearLayout contenedorPreguntas = seccionView.findViewById(R.id.container_preguntas);
+            ImageView ivChevron = seccionView.findViewById(R.id.iv_chevron);
+
+            tvTitulo.setText(seccion.titulo);
+
+            for (String[] item : seccion.items) {
+                View preguntaView = inflater.inflate(R.layout.item_ayuda_pregunta, contenedorPreguntas, false);
+                ((TextView) preguntaView.findViewById(R.id.tv_pregunta)).setText(item[0]);
+                ((TextView) preguntaView.findViewById(R.id.tv_respuesta)).setText(item[1]);
+                contenedorPreguntas.addView(preguntaView);
+            }
+
+            header.setOnClickListener(v -> {
+                boolean estaAbierto = contenedorPreguntas.getVisibility() == View.VISIBLE;
+                contenedorPreguntas.setVisibility(estaAbierto ? View.GONE : View.VISIBLE);
+                ivChevron.animate().rotation(estaAbierto ? 0f : 180f).setDuration(200).start();
+            });
+
+            contenedor.addView(seccionView);
+        }
+
+        return view;
+    }
+}

--- a/android/app/src/main/res/drawable/ic_chevron_down.xml
+++ b/android/app/src/main/res/drawable/ic_chevron_down.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M16.59,8.59L12,13.17 7.41,8.59 6,10l6,6 6,-6 -1.41,-1.41z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_nav_help.xml
+++ b/android/app/src/main/res/drawable/ic_nav_help.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M11,18h2v-2h-2v2zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8zM12,6c-2.21,0 -4,1.79 -4,4h2c0,-1.1 0.9,-2 2,-2s2,0.9 2,2c0,2 -3,1.75 -3,5h2c0,-2.25 3,-2.5 3,-5 0,-2.21 -1.79,-4 -4,-4z"/>
+</vector>

--- a/android/app/src/main/res/layout-land/activity_main.xml
+++ b/android/app/src/main/res/layout-land/activity_main.xml
@@ -14,7 +14,10 @@
         android:background="@color/green_primary"
         app:menu="@menu/bottom_navigation_menu"
         app:itemIconTint="@color/navigation_tint"
-        app:itemTextColor="@color/navigation_text_color" />
+        app:itemTextColor="@color/navigation_text_color"
+        app:labelVisibilityMode="unlabeled"
+        app:itemPaddingTop="0dp"
+        app:itemPaddingBottom="0dp" />
 
     <View
         android:layout_width="1dp"

--- a/android/app/src/main/res/layout/fragment_ayuda.xml
+++ b/android/app/src/main/res/layout/fragment_ayuda.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@color/background_app">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="16dp"
+        android:paddingBottom="16dp"
+        android:clipToPadding="false">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <!-- Tarjeta cabecera -->
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                app:cardCornerRadius="12dp"
+                app:cardElevation="2dp"
+                app:strokeColor="@color/gray_200"
+                app:strokeWidth="1dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:padding="16dp"
+                    android:gravity="center_vertical">
+
+                    <ImageView
+                        android:layout_width="40dp"
+                        android:layout_height="40dp"
+                        android:src="@drawable/ic_nav_help"
+                        android:padding="4dp"
+                        app:tint="@color/accent" />
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:layout_marginStart="12dp"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Centro de ayuda"
+                            android:textColor="@color/green_primary"
+                            android:textSize="18sp"
+                            android:textStyle="bold" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="4dp"
+                            android:text="Encuentra respuestas sobre el uso de la aplicación Android."
+                            android:textColor="@color/text_secondary"
+                            android:textSize="13sp" />
+                    </LinearLayout>
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <!-- Contenedor de secciones (se rellena desde el fragment) -->
+            <LinearLayout
+                android:id="@+id/container_secciones"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
+
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/android/app/src/main/res/layout/item_ayuda_pregunta.xml
+++ b/android/app/src/main/res/layout/item_ayuda_pregunta.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <!-- Divisor -->
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/gray_200" />
+
+    <!-- Pregunta -->
+    <TextView
+        android:id="@+id/tv_pregunta"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="12dp"
+        android:paddingBottom="4dp"
+        android:textColor="@color/text_primary"
+        android:textSize="14sp"
+        android:textStyle="bold" />
+
+    <!-- Respuesta -->
+    <TextView
+        android:id="@+id/tv_respuesta"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="2dp"
+        android:paddingBottom="12dp"
+        android:textColor="@color/text_secondary"
+        android:textSize="13sp"
+        android:lineSpacingMultiplier="1.3" />
+
+</LinearLayout>

--- a/android/app/src/main/res/layout/item_ayuda_seccion.xml
+++ b/android/app/src/main/res/layout/item_ayuda_seccion.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="12dp"
+    app:cardCornerRadius="12dp"
+    app:cardElevation="2dp"
+    app:strokeColor="@color/gray_200"
+    app:strokeWidth="1dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <!-- Cabecera de sección (clickable para acordeón) -->
+        <LinearLayout
+            android:id="@+id/header_seccion"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:padding="16dp"
+            android:gravity="center_vertical"
+            android:background="@color/green_primary"
+            android:clickable="true"
+            android:focusable="true">
+
+            <TextView
+                android:id="@+id/tv_titulo_seccion"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textColor="@color/white"
+                android:textSize="15sp"
+                android:textStyle="bold" />
+
+            <ImageView
+                android:id="@+id/iv_chevron"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:src="@drawable/ic_chevron_down"
+                app:tint="@color/accent" />
+        </LinearLayout>
+
+        <!-- Contenido de preguntas (colapsable) -->
+        <LinearLayout
+            android:id="@+id/container_preguntas"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone" />
+
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/android/app/src/main/res/menu/bottom_navigation_menu.xml
+++ b/android/app/src/main/res/menu/bottom_navigation_menu.xml
@@ -17,6 +17,11 @@
         android:visible="false" />
 
     <item
+        android:id="@+id/menu_ayuda"
+        android:icon="@drawable/ic_nav_help"
+        android:title="Ayuda" />
+
+    <item
         android:id="@+id/menu_login"
         android:icon="@drawable/ic_nav_login"
         android:title="Login" />


### PR DESCRIPTION
## Summary

- New `AyudaFragment` with eight expandable sections covering login, navigation, dashboard, centres, trees, devices, alerts and FAQ
- Content inflated dynamically from static data — no external libraries
- New `menu_ayuda` item with a question-mark icon added to the shared bottom navigation menu (used by both BottomNavigationView in portrait and NavigationRailView in landscape)
- Two new drawables: `ic_nav_help` (nav icon) and `ic_chevron_down` (accordion toggle with 200 ms rotation animation)
- Three new layout files: `fragment_ayuda`, `item_ayuda_seccion`, `item_ayuda_pregunta`

## Test plan

- [ ] «Ayuda» item appears in the bottom navigation (portrait)
- [ ] «Ayuda» item appears in the navigation rail (landscape)
- [ ] Tapping the item loads `AyudaFragment` correctly
- [ ] All eight sections render with their title in the green header
- [ ] Tapping a section header expands/collapses its content with chevron animation
- [ ] Multiple sections can be open simultaneously and independently
- [ ] Back button from Ayuda returns to the previous screen