### PR TITLE
fix(frontend): isolate Leaflet map stacking context to prevent overlap with modals

### DIFF
--- a/frontend/src/pages/centros/DetalleCentro.jsx
+++ b/frontend/src/pages/centros/DetalleCentro.jsx
@@ -286,7 +286,7 @@ function DetalleCentro() {
             )}
           </div>
           {centro.latitud && centro.longitud && (
-            <div className="rounded overflow-hidden border border-gray-200" style={{ height: '200px' }}>
+            <div className="rounded overflow-hidden border border-gray-200" style={{ height: '200px', isolation: 'isolate' }}>
               <MapContainer
                 center={[parseFloat(centro.latitud), parseFloat(centro.longitud)]}
                 zoom={15}


### PR DESCRIPTION
## Summary
- Add `isolation: 'isolate'` to the Leaflet map wrapper in `DetalleCentro`
- Prevents Leaflet's internal z-indexes (400–600) from escaping the map container and rendering above modal overlays