### PR TITLE
release: deploy JWT expired session handling to production

### DIFF
--- a/android/app/src/main/java/com/example/proyectoarboles/api/AuthInterceptor.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/api/AuthInterceptor.java
@@ -1,7 +1,10 @@
 package com.example.proyectoarboles.api;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
+
+import com.example.proyectoarboles.activities.MainActivity;
 
 import java.io.IOException;
 
@@ -11,10 +14,12 @@ import okhttp3.Response;
 
 public class AuthInterceptor implements Interceptor {
 
+    private final Context context;
     private final SharedPreferences sharedPreferences;
 
     public AuthInterceptor(Context context) {
-        this.sharedPreferences = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE);
+        this.context = context.getApplicationContext();
+        this.sharedPreferences = this.context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE);
     }
 
     @Override
@@ -23,12 +28,23 @@ public class AuthInterceptor implements Interceptor {
         Request original = chain.request();
 
         if (token != null) {
-            Request request = original.newBuilder()
+            original = original.newBuilder()
                     .header("Authorization", "Bearer " + token)
                     .build();
-            return chain.proceed(request);
         }
 
-        return chain.proceed(original);
+        Response response = chain.proceed(original);
+
+        if (response.code() == 401) {
+            sharedPreferences.edit()
+                    .remove("token")
+                    .remove("user")
+                    .apply();
+            Intent intent = new Intent(context, MainActivity.class);
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+            context.startActivity(intent);
+        }
+
+        return response;
     }
 }

--- a/backend/src/main/java/com/example/gardenmonitor/security/JwtAuthFilter.java
+++ b/backend/src/main/java/com/example/gardenmonitor/security/JwtAuthFilter.java
@@ -46,6 +46,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                             userDetails, null, userDetails.getAuthorities());
             auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
             SecurityContextHolder.getContext().setAuthentication(auth);
+        } else {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token inválido o expirado");
+            return;
         }
 
         filterChain.doFilter(request, response);

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -24,21 +24,18 @@ api.interceptors.request.use(
 );
 
   // Interceptor para responses (manejo de errores global)
+  let redirectingToLogin = false;
+
   api.interceptors.response.use(
     (response) => {
       return response;
     },
     (error) => {
-      // Manejo de errores global
-      if (error.response) {
-        // El servidor respondió con un código de error
-        console.error('Error response:', error.response.status);
-      } else if (error.request) {
-        // La petición fue hecha pero no hubo respuesta
-        console.error('Error request:', error.request);
-      } else {
-        // Algo pasó al configurar la petición
-        console.error('Error:', error.message);
+      if (error.response?.status === 401 && !redirectingToLogin) {
+        redirectingToLogin = true;
+        localStorage.removeItem('token');
+        localStorage.removeItem('user');
+        window.location.href = '/login';
       }
       return Promise.reject(error);
     }


### PR DESCRIPTION
## Changes

Merges fix for expired JWT session handling across all platforms.

- **Backend**: `JwtAuthFilter` returns 401 explicitly on invalid/expired token
- **Frontend**: Axios interceptor redirects to login on 401
- **Android**: `AuthInterceptor` clears session and restarts app on 401

Tested locally with a 30-second token expiration. See PR #317 for full detail.