### PR TITLE
docs: fix JWT expired token HTTP status code in security test table

### DIFF
--- a/docs/ENTREGA_PROYECTO_INTERMODULAR.md
+++ b/docs/ENTREGA_PROYECTO_INTERMODULAR.md
@@ -1798,7 +1798,7 @@ Las pruebas del backend se realizaron con **Postman** sobre la API desplegada en
 | POST `/api/centros` sin JWT | Sin cabecera `Authorization` | 403 Forbidden | ✓ 403 |
 | `GET /api/usuarios` con rol COORDINADOR | JWT con `rol: COORDINADOR` | 403 Forbidden | ✓ 403 |
 | `POST /api/usuarios` con rol COORDINADOR | JWT con `rol: COORDINADOR` | 403 Forbidden | ✓ 403 |
-| JWT expirado o manipulado | Token con firma inválida | 403 Forbidden | ✓ 403 |
+| JWT expirado o manipulado | Token con firma inválida | 401 Unauthorized | ✓ 401 |
 
 ---
 


### PR DESCRIPTION
## Summary

- Corrects the expected HTTP response code for expired/invalid JWT from `403 Forbidden` to `401 Unauthorized` in the security test table
- Reflects the backend fix introduced in PR #317 (`JwtAuthFilter` now returns 401 explicitly)