### PR TITLE
feat: show ESP32 device count in centros list (web + Android)

### DIFF
--- a/android/app/src/main/java/com/example/proyectoarboles/adapter/CentroEducativoAdapter.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/adapter/CentroEducativoAdapter.java
@@ -49,12 +49,14 @@ public class CentroEducativoAdapter extends RecyclerView.Adapter<CentroEducativo
         private TextView textViewNombre;
         private TextView textViewPoblacion;
         private TextView textViewIsla;
+        private TextView textViewNumDispositivos;
 
         public CentroEducativoViewHolder(@NonNull View itemView) {
             super(itemView);
             textViewNombre = itemView.findViewById(R.id.textViewNombreCentro);
             textViewPoblacion = itemView.findViewById(R.id.textViewPoblacion);
             textViewIsla = itemView.findViewById(R.id.textViewIsla);
+            textViewNumDispositivos = itemView.findViewById(R.id.textViewNumDispositivos);
         }
 
         public void bind(CentroEducativo centro, OnItemClickListener listener) {
@@ -63,6 +65,7 @@ public class CentroEducativoAdapter extends RecyclerView.Adapter<CentroEducativo
             String isla = IslaUtils.formatear(centro.getIsla());
             textViewPoblacion.setText(poblacion);
             textViewIsla.setText(isla.equals("-") ? "" : isla);
+            textViewNumDispositivos.setText(String.valueOf(centro.getNumDispositivos()));
             itemView.setOnClickListener(v -> listener.onVerDetalleClick(centro));
         }
     }

--- a/android/app/src/main/java/com/example/proyectoarboles/model/CentroEducativo.java
+++ b/android/app/src/main/java/com/example/proyectoarboles/model/CentroEducativo.java
@@ -44,6 +44,9 @@ public class CentroEducativo {
     @SerializedName("fechaCreacion")
     private String fechaCreacion;
 
+    @SerializedName("numDispositivos")
+    private Integer numDispositivos;
+
     // Getters
     public Long getId() { return id; }
     public String getNombre() { return nombre; }
@@ -58,6 +61,7 @@ public class CentroEducativo {
     public String getTelefono() { return telefono; }
     public String getEmail() { return email; }
     public String getFechaCreacion() { return fechaCreacion; }
+    public int getNumDispositivos() { return numDispositivos != null ? numDispositivos : 0; }
 
     // Setters
     public void setId(Long id) { this.id = id; }

--- a/android/app/src/main/res/layout/item_centros.xml
+++ b/android/app/src/main/res/layout/item_centros.xml
@@ -21,8 +21,9 @@
         android:padding="16dp">
 
         <LinearLayout
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:orientation="vertical">
 
             <TextView
@@ -47,6 +48,30 @@
                 android:layout_height="wrap_content"
                 android:textColor="@color/text_secondary"
                 android:textSize="14sp" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:layout_width="18dp"
+                android:layout_height="18dp"
+                android:layout_marginEnd="4dp"
+                android:contentDescription="@string/dispositivos_icon_desc"
+                android:src="@drawable/ic_cpu"
+                app:tint="@color/green_primary" />
+
+            <TextView
+                android:id="@+id/textViewNumDispositivos"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/text_primary"
+                android:textSize="14sp"
+                android:textStyle="bold" />
 
         </LinearLayout>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">Proyecto Arboles</string>
     <string name="label_activo">Usuario activo</string>
+    <string name="dispositivos_icon_desc">Número de dispositivos</string>
 </resources>

--- a/backend/src/main/java/com/example/gardenmonitor/model/CentroEducativo.java
+++ b/backend/src/main/java/com/example/gardenmonitor/model/CentroEducativo.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.annotations.Formula;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -106,6 +107,9 @@ public class CentroEducativo {
     @OneToMany(mappedBy = "centroEducativo", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Arbol> arboles = new ArrayList<>();
 
+    @Formula("(SELECT COUNT(*) FROM dispositivo_esp32 d WHERE d.centro_id = id)")
+    private Integer numDispositivos;
+
     /**
      * Constructor vacío requerido por JPA.
      */
@@ -182,6 +186,10 @@ public class CentroEducativo {
 
     public LocalDateTime getFechaCreacion() { return fechaCreacion; }
     public void setFechaCreacion(LocalDateTime fechaCreacion) { this.fechaCreacion = fechaCreacion; }
+
+    public Integer getNumDispositivos() {
+        return numDispositivos != null ? numDispositivos : 0;
+    }
 
     public List<Arbol> getArboles() {
         return arboles;

--- a/frontend/src/pages/centros/ListadoCentros.jsx
+++ b/frontend/src/pages/centros/ListadoCentros.jsx
@@ -1,4 +1,4 @@
-import { School, Plus } from 'lucide-react';
+import { School, Plus, Cpu } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { getCentros } from '../../services/centrosService';
 import { useFetch } from '../../hooks/useFetch';
@@ -96,6 +96,9 @@ function ListadoCentros() {
                       <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
                         Responsable
                       </th>
+                      <th className="px-6 py-3 text-center text-xs font-medium text-white uppercase tracking-wider">
+                        Dispositivos
+                      </th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">
                         Fecha Creación
                       </th>
@@ -122,6 +125,12 @@ function ListadoCentros() {
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap">
                           <div className="text-sm text-gray-500">{centro.responsable}</div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-center">
+                          <span className="inline-flex items-center gap-1 text-sm text-gray-700">
+                            <Cpu className="w-4 h-4 text-brand-secondary" />
+                            {centro.numDispositivos ?? 0}
+                          </span>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap">
                           <div className="text-sm text-gray-500">
@@ -167,6 +176,11 @@ function ListadoCentros() {
                     </p>
                     <p className="text-sm text-gray-600 mb-1">
                       <span className="font-medium">Responsable:</span> {centro.responsable}
+                    </p>
+                    <p className="text-sm text-gray-600 mb-1 flex items-center gap-1">
+                      <span className="font-medium">Dispositivos:</span>
+                      <Cpu className="w-4 h-4 text-brand-secondary" />
+                      {centro.numDispositivos ?? 0}
                     </p>
                     <p className="text-sm text-gray-600 mb-3">
                       <span className="font-medium">Creación:</span>{' '}


### PR DESCRIPTION
## Summary

- **Backend**: `CentroEducativo` entity now exposes a calculated `numDispositivos` field. Uses Hibernate `@Formula` to count associated devices in a single subquery — no N+1.
- **Frontend**: New `Dispositivos` column with a Cpu icon in the desktop table and the mobile cards.
- **Android**: New right-aligned badge with Cpu icon and counter in each centro item of the listing.

## Test plan

- [x] Backend restart picks up the new field — `GET /api/centros` includes `"numDispositivos": N`
- [x] Web: column shows correct count for each centro on desktop and mobile views
- [x] Android (`localEmulator`/`localDevice` flavor): badge appears with correct count
- [x] After `develop → main` deploy, `productionDebug` flavor also shows the count