### PR TITLE
fix(backend): allow new Vercel deployment origin in CORS policy

### DIFF
--- a/backend/src/main/java/com/example/gardenmonitor/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/gardenmonitor/config/SecurityConfig.java
@@ -68,7 +68,8 @@ public class SecurityConfig {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOriginPatterns(List.of(
             "http://localhost:5173",
-            "https://vocational-training-final-project.vercel.app"
+            "https://vocational-training-final-project.vercel.app",
+            "https://app-proyectoarboles-org.vercel.app"
         ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));


### PR DESCRIPTION
## Summary
- Adds `https://app-proyectoarboles-org.vercel.app` to the backend CORS allowed origins
- Existing origins remain unchanged