### PR TITLE
fix(backend): allow custom domain in CORS policy

### DIFF
--- a/backend/src/main/java/com/example/gardenmonitor/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/gardenmonitor/config/SecurityConfig.java
@@ -69,7 +69,8 @@ public class SecurityConfig {
         config.setAllowedOriginPatterns(List.of(
             "http://localhost:5173",
             "https://vocational-training-final-project.vercel.app",
-            "https://app-proyectoarboles-org.vercel.app"
+            "https://app-proyectoarboles-org.vercel.app",
+            "https://app.proyectoarboles.org"
         ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));


### PR DESCRIPTION
## Summary
- Adds `https://app.proyectoarboles.org` to the backend CORS allowed origins